### PR TITLE
feat: add `fetch` as CLI alias for `extract`

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -501,6 +501,10 @@ def extract(
         raise click.Abort() from None
 
 
+# Add fetch as an alias for extract
+main.add_command(extract, name="fetch")
+
+
 # =============================================================================
 # Enrich Command Group
 # =============================================================================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -311,6 +311,23 @@ class TestExtractCommand:
         pass
 
 
+class TestFetchCommand:
+    """Tests for the fetch command (alias for extract)."""
+
+    def test_fetch_help(self, runner):
+        """Should show fetch help (same as extract)."""
+        result = runner.invoke(main, ["fetch", "--help"])
+        assert result.exit_code == 0
+        assert "Extract content" in result.output
+        assert "--json" in result.output
+
+    def test_fetch_in_main_help(self, runner):
+        """Should show fetch as a command in main help."""
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "fetch" in result.output
+
+
 class TestEnrichGroup:
     """Tests for the enrich command group."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -1122,7 +1122,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "parallel-web", specifier = ">=0.4.0" },
     { name = "parallel-web-tools", extras = ["all", "spark"], marker = "extra == 'dev'" },
-    { name = "parallel-web-tools", extras = ["cli", "polars", "duckdb", "snowflake", "bigquery"], marker = "extra == 'all'" },
+    { name = "parallel-web-tools", extras = ["polars", "duckdb", "snowflake", "bigquery"], marker = "extra == 'all'" },
     { name = "polars", specifier = ">=1.37.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyarrow", specifier = ">=18.0.0" },
@@ -1140,7 +1140,7 @@ requires-dist = [
     { name = "sqlalchemy", marker = "extra == 'bigquery'", specifier = ">=2.0.0" },
     { name = "sqlalchemy-bigquery", marker = "extra == 'bigquery'", specifier = ">=1.11.0" },
 ]
-provides-extras = ["cli", "polars", "duckdb", "snowflake", "bigquery", "bigquery-native", "spark", "all", "dev"]
+provides-extras = ["polars", "duckdb", "snowflake", "bigquery", "bigquery-native", "spark", "all", "dev"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "ipykernel", specifier = ">=7.1.0" }]


### PR DESCRIPTION
## Summary

- Adds `fetch` as an alternative command name for the `extract` command
- Both commands are fully equivalent and share the same implementation
- Uses Click's `add_command()` to register the alias cleanly

## Test plan

- [x] Verify `parallel-cli fetch --help` shows same help as `parallel-cli extract --help`
- [x] Verify `fetch` appears in main `--help` output
- [x] All existing tests pass
- [x] New tests added for the `fetch` alias

## Usage

```bash
# These are now equivalent:
parallel-cli extract https://example.com
parallel-cli fetch https://example.com
```