### PR TITLE
fix: suppress SIGPIPE error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           echo ""
           echo "Archive contents:"
           if [ -f "dist/parallel-cli-${{ matrix.platform }}.zip" ]; then
-            unzip -l "dist/parallel-cli-${{ matrix.platform }}.zip" | head -20
+            unzip -l "dist/parallel-cli-${{ matrix.platform }}.zip" | head -20 || true
           fi
 
       - name: Verify checksum file exists


### PR DESCRIPTION
## Summary

- Add `|| true` to suppress SIGPIPE (exit code 141) when `unzip -l | head -20` causes head to exit early

## Context

The Windows build in v0.0.8 release failed with exit code 141 even though the build itself succeeded. This is a false positive from the diagnostic "List build output" step.

## Test plan

- [x] Workflow syntax is valid
- [ ] Re-run release workflow succeeds on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)