### PR TITLE
feat: upload install script as release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,12 +88,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
           pattern: binary-*
           merge-multiple: true
+
+      - name: Copy install script to artifacts
+        run: cp install-cli.sh artifacts/install.sh
 
       - name: List artifacts
         run: |


### PR DESCRIPTION
## Summary

- Add install script (`install.sh`) as a release asset alongside the platform binaries
- Enables stable URL: `https://github.com/parallel-web/parallel-web-tools/releases/latest/download/install.sh`

## Why

This allows us to redirect `https://parallel.ai/install.sh` to the released version of the install script, avoiding issues with unreleased changes on main.

## Test plan

- [ ] Create a test release and verify `install.sh` appears in assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)