### PR TITLE
chore: release 0.0.10

### DIFF
--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -27,7 +27,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.0.9
+parallel-web-tools>=0.0.10
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.0.9"
+version = "0.0.10"
 description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,7 +225,7 @@ class TestMainCLI:
         """Should show version."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.0.9" in result.output
+        assert "0.0.10" in result.output
 
 
 class TestAuthCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.0.9"
+version = "0.0.10"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bump version to 0.0.10 for release.

## Changes in 0.0.10

### Features
- **Snowflake Integration:** Updated to use batched UDTF with `end_partition()` for improved performance (#19)
  - All rows in a partition are now processed in a single API call
  - Added `PARTITION BY` documentation with examples (by 1, by column, by batch_id)
  - Increased UDTF timeout to 30 minutes

### Improvements
- Reduced poll interval to 2s for faster Snowflake responses
- Simplified Snowflake UDTF to single function with DEFAULT parameter
- Refactored shared `run_enrichment` helper

## Release Checklist

After merging:
1. Create a GitHub Release with tag `v0.0.10`
2. Add release notes (copy from above)
3. Publish release → triggers binary build and PyPI publish

## Test plan

- [x] Version updated in pyproject.toml
- [x] Version updated in parallel_web_tools/__init__.py
- [x] Version updated in tests/test_cli.py
- [x] Version updated in bigquery cloud function requirements.txt
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)