### PR TITLE
chore: release 0.0.11

### DIFF
--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -27,7 +27,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.0.10
+parallel-web-tools>=0.0.11
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.0.10"
+version = "0.0.11"
 description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,7 +225,7 @@ class TestMainCLI:
         """Should show version."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.0.10" in result.output
+        assert "0.0.11" in result.output
 
 
 class TestAuthCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.0.10"
+version = "0.0.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version to 0.0.11
- Update version in all required locations per maintainers.md

## Changes since 0.0.10
- feat: add full API parity for search and extract CLI commands (#21)

## Checklist
- [x] `pyproject.toml`
- [x] `parallel_web_tools/__init__.py`
- [x] `tests/test_cli.py`
- [x] `integrations/bigquery/cloud_function/requirements.txt`