### PR TITLE
feat: add --no-wait, status, and poll to enrichment CLI

### DIFF
--- a/parallel_web_tools/core/__init__.py
+++ b/parallel_web_tools/core/__init__.py
@@ -11,9 +11,12 @@ from parallel_web_tools.core.auth import (
 )
 from parallel_web_tools.core.batch import (
     build_output_schema,
+    create_task_group,
     enrich_batch,
     enrich_single,
     extract_basis,
+    get_task_group_status,
+    poll_task_group,
     run_tasks,
 )
 from parallel_web_tools.core.research import (
@@ -77,9 +80,12 @@ __all__ = [
     "parse_input_and_output_models",
     # Batch
     "build_output_schema",
+    "create_task_group",
     "enrich_batch",
     "enrich_single",
     "extract_basis",
+    "get_task_group_status",
+    "poll_task_group",
     "run_tasks",
     # Runner
     "run_enrichment",

--- a/parallel_web_tools/processors/csv.py
+++ b/parallel_web_tools/processors/csv.py
@@ -2,13 +2,15 @@
 
 import csv
 import logging
+from typing import Any
 
 from parallel_web_tools.core import InputSchema, parse_input_and_output_models, run_tasks
+from parallel_web_tools.core.batch import create_task_group
 
 logger = logging.getLogger(__name__)
 
 
-def process_csv(schema: InputSchema):
+def process_csv(schema: InputSchema, no_wait: bool = False) -> dict[str, Any] | None:
     """Process CSV file and enrich data."""
     logger.info("Processing CSV file: %s", schema.source)
 
@@ -21,6 +23,9 @@ def process_csv(schema: InputSchema):
         for row in csv_reader:
             data.append(dict(row))
 
+    if no_wait:
+        return create_task_group(data, InputModel, OutputModel, schema.processor)
+
     # Process all rows in batch
     output_rows = run_tasks(data, InputModel, OutputModel, schema.processor)
 
@@ -30,3 +35,5 @@ def process_csv(schema: InputSchema):
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(output_rows)
+
+    return None

--- a/parallel_web_tools/processors/duckdb.py
+++ b/parallel_web_tools/processors/duckdb.py
@@ -1,15 +1,17 @@
 """DuckDB processor for data enrichment."""
 
 import os
+from typing import Any
 
 import duckdb
 import polars as pl
 
 from parallel_web_tools.core import InputSchema, parse_input_and_output_models, run_tasks
+from parallel_web_tools.core.batch import create_task_group
 from parallel_web_tools.core.sql_utils import quote_identifier
 
 
-def process_duckdb(schema: InputSchema) -> None:
+def process_duckdb(schema: InputSchema, no_wait: bool = False) -> dict[str, Any] | None:
     """Process DuckDB table and enrich data."""
     InputModel, OutputModel = parse_input_and_output_models(schema)
     duckdb_file = os.getenv("DUCKDB_FILE")
@@ -22,8 +24,13 @@ def process_duckdb(schema: InputSchema) -> None:
     with duckdb.connect(duckdb_file) as con:
         data = con.sql(f"SELECT * from {source_quoted}").pl().to_dicts()
 
+        if no_wait:
+            return create_task_group(data, InputModel, OutputModel, schema.processor)
+
         output_rows = run_tasks(data, InputModel, OutputModel, schema.processor)
 
         # Write output_rows to the target table
         df = pl.DataFrame(output_rows)  # noqa: F841
         con.sql(f"CREATE OR REPLACE TABLE {target_quoted} AS SELECT * FROM df")
+
+    return None


### PR DESCRIPTION
## Summary

- Add `--no-wait` flag to `enrich run` so users can fire-and-forget long-running enrichment jobs
- Add `enrich status <taskgroup_id>` command to check task group progress
- Add `enrich poll <taskgroup_id>` command to wait for completion and collect results
- Extract `create_task_group()`, `get_task_group_status()`, `poll_task_group()` as reusable core functions
- Thread `no_wait` through runner and all three processors (CSV, DuckDB, BigQuery)

## Test plan

- [x] `uv run pytest tests/ -q` — 381 tests pass
- [x] `uv run ruff check . && uv run ruff format --check .` — clean
- [x] Manual: `parallel-cli enrich run --no-wait --source-type csv ...` prints taskgroup_id
- [x] Manual: `parallel-cli enrich status <tgrp_id>` shows progress
- [x] Manual: `parallel-cli enrich poll <tgrp_id> --json` waits and outputs results