### PR TITLE
chore: release 0.0.13rc1

### DIFF
--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -27,7 +27,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.0.12"
+__version__ = "0.0.13rc1"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.0.12
+parallel-web-tools>=0.0.13rc1
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.0.12"
+version = "0.0.13rc1"
 description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,7 +234,7 @@ class TestMainCLI:
         """Should show version."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.0.12" in result.output
+        assert "0.0.13rc1" in result.output
 
 
 class TestAuthCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1057,7 +1057,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.0.12"
+version = "0.0.13rc1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version from `0.0.12` to `0.0.13rc1` across all version locations (`pyproject.toml`, `__init__.py`, `test_cli.py`, BigQuery cloud function requirements, and `uv.lock`)

## Test plan
- [ ] Verify CI passes (linting, type checks, tests)
- [ ] Validate `--version` CLI output shows `0.0.13rc1`
- [ ] Test install from built wheel