### PR TITLE
chore: bump version to 0.0.13rc2

### DIFF
--- a/install-cli.sh
+++ b/install-cli.sh
@@ -291,10 +291,11 @@ main() {
         "${BINARY_NAME}" --version 2>/dev/null || true
         echo ""
         echo "Next steps:"
-        echo "  1. Authenticate:  ${BINARY_NAME} login"
-        echo "  2. Search:        ${BINARY_NAME} search \"your query\""
-        echo "  3. Extract:       ${BINARY_NAME} extract https://example.com"
-        echo "  4. Enrich:        ${BINARY_NAME} enrich run --help"
+        echo "  1. Authenticate:     ${BINARY_NAME} login"
+        echo "  2. Search:           ${BINARY_NAME} search \"Parallel Web Systems\""
+        echo "  3. Extract:          ${BINARY_NAME} extract https://parallel.ai"
+        echo "  4. Deep Research:    ${BINARY_NAME} research run \"Detailed report on the latest AI research\""
+        echo "  5. Enrich:           ${BINARY_NAME} enrich run --help"
         echo ""
     else
         print_error "Installation verification failed"

--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -27,7 +27,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.0.13rc1"
+__version__ = "0.0.13rc2"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.0.13rc1
+parallel-web-tools>=0.0.13rc2
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.0.13rc1"
+version = "0.0.13rc2"
 description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -26,7 +26,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "parallel-web>=0.4.0",
+    "parallel-web>=0.4.1",
     "python-dotenv>=1.0.0",
     # CLI dependencies (minimal - search, extract, enrich with CLI args)
     "click>=8.1.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,7 +234,7 @@ class TestMainCLI:
         """Should show version."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.0.13rc1" in result.output
+        assert "0.0.13rc2" in result.output
 
 
 class TestAuthCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1040,7 +1040,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1050,14 +1050,14 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/c1/9ec5d5e3cb68053dec5b3429772116b963b4d48eea9bc24055bb8c774ace/parallel_web-0.4.0.tar.gz", hash = "sha256:1d044ae7ac66a4d61200b288bca3d119a25799023ed01f68c25a39c5fcf98b4e", size = 132784, upload-time = "2026-01-13T02:07:03.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/80/7115d10c0d07235fc155e8c0d06908cc8a9b52d3ff3e45f59bac9546e49f/parallel_web-0.4.1.tar.gz", hash = "sha256:47519dc475fbf8156b3fb117ae018bca50a52c95a712c97999d79491083fc1c3", size = 135251, upload-time = "2026-01-29T00:26:21.776Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/3f/1db79379e1567288165dbe48ab6db5c1896396b8b035da7af5b74fa31cf5/parallel_web-0.4.0-py3-none-any.whl", hash = "sha256:b0eddbc372e07490f4c83c068cbed818fb73fdf9bfba5c9b0e556ad2d92e0aad", size = 138908, upload-time = "2026-01-13T02:07:02.193Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c8/a423bfcfb8215bb495385020e025791ef45cc55d35cac36c4caed7627980/parallel_web-0.4.1-py3-none-any.whl", hash = "sha256:f581c373382443720209f201d628a00b845bc4061aeef4774ae2ee8a7f9afd2d", size = 139464, upload-time = "2026-01-29T00:26:20.459Z" },
 ]
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.0.13rc1"
+version = "0.0.13rc2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -1143,7 +1143,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "nest-asyncio", marker = "extra == 'duckdb'", specifier = ">=1.6.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.3.0" },
-    { name = "parallel-web", specifier = ">=0.4.0" },
+    { name = "parallel-web", specifier = ">=0.4.1" },
     { name = "parallel-web-tools", extras = ["all", "spark"], marker = "extra == 'dev'" },
     { name = "parallel-web-tools", extras = ["cli"], marker = "extra == 'bigquery'" },
     { name = "parallel-web-tools", extras = ["cli", "polars"], marker = "extra == 'duckdb'" },


### PR DESCRIPTION
## Summary
- Bump version from `0.0.13rc1` to `0.0.13rc2`
- Upgrade `parallel-web` SDK dependency from `>=0.4.0` to `>=0.4.1` (fixes `extract` requiring `betas` parameter)
- Update `install-cli.sh` next steps to include deep research command

## Test plan
- [x] All 381 tests pass
- [ ] Verify `parallel-cli extract` works without `betas` error