### PR TITLE
fix: slim down standalone CLI binary by ~42%

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --extra cli && uv pip install pyinstaller>=6.0.0
 
       - name: Get version
         id: version

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -35,14 +35,14 @@ def ensure_dependencies():
     if has_uv():
         print("Using uv to install dependencies...")
         subprocess.run(
-            ["uv", "pip", "install", "-e", ".[dev]"],
+            ["uv", "pip", "install", "-e", ".[cli]", "pyinstaller>=6.0.0"],
             cwd=project_root,
             check=True,
         )
     else:
         print("Using pip to install dependencies...")
         subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-e", ".[dev]"],
+            [sys.executable, "-m", "pip", "install", "-e", ".[cli]", "pyinstaller>=6.0.0"],
             cwd=project_root,
             check=True,
         )


### PR DESCRIPTION
## Summary

- Build standalone CLI with only `[cli]` extras instead of `[all]`
- The binary doesn't need duckdb, polars, pyarrow, bigquery, snowflake, or spark — those are for programmatic integrations
- Update both `release.yml` and `scripts/build.py` to install `.[cli]` + pyinstaller

## Benchmarks (macOS arm64)

| Metric | `--all-extras` | `--extra cli` | Diff |
|---|---|---|---|
| Folder size | 76.4 MB | 40.4 MB | **-47%** |
| Archive size | 37.4 MB | 21.7 MB | **-42%** |
| Startup time | ~0.16s | ~0.16s | No change |

## Test plan

- [x] Built and smoke-tested locally on macOS arm64
- [x] `parallel-cli --version`, `--help`, `enrich run --help` all work
- [ ] CI passes
- [ ] Verify binary builds on all platforms via release workflow