### PR TITLE
docs: update README for Python 3.10+ and research command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ export PARALLEL_API_KEY=your_api_key
 parallel-cli search "What is Anthropic's latest AI model?" --json
 
 # Keyword search with filters
-parallel-cli search -q "bitcoin price" --after-date 2025-01-01 --json
+parallel-cli search -q "bitcoin price" --after-date 2026-01-01 --json
 
 # Search specific domains
 parallel-cli search "SEC filings for Apple" --include-domains sec.gov --json


### PR DESCRIPTION
## Summary

- Add Python 3.10+ requirement note to Installation section
- Add `research` command tree (run, status, poll, processors) to CLI Overview
- Update standalone binary note to mention `research` support
- Update example date from 2024 to 2025

## Test plan

- [x] README renders correctly