### PR TITLE
feat: add Monitor API support to CLI

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -19,18 +19,25 @@ from parallel_web_tools.core import (
     AVAILABLE_PROCESSORS,
     FINDALL_GENERATORS,
     JSON_SCHEMA_TYPE_MAP,
+    MONITOR_CADENCES,
     RESEARCH_PROCESSORS,
     cancel_findall_run,
     create_findall_run,
+    create_monitor,
     create_research_task,
+    delete_monitor,
     get_api_key,
     get_auth_status,
     get_findall_result,
     get_findall_status,
+    get_monitor,
+    get_monitor_event_group,
     get_research_status,
     get_task_group_status,
     get_user_agent,
     ingest_findall,
+    list_monitor_events,
+    list_monitors,
     logout,
     poll_findall,
     poll_research,
@@ -38,6 +45,8 @@ from parallel_web_tools.core import (
     run_enrichment_from_dict,
     run_findall,
     run_research,
+    simulate_monitor_event,
+    update_monitor,
 )
 
 # Standalone CLI (PyInstaller) has limited features to reduce bundle size
@@ -2088,6 +2097,349 @@ def _output_findall_result(
 
         if not output_file:
             console.print("[dim]Use --output to save full results, or --json for machine-readable output[/dim]")
+
+
+# =============================================================================
+# Monitor Commands
+# =============================================================================
+
+
+@main.group()
+def monitor():
+    """Monitor: continuously track the web for changes."""
+    pass
+
+
+@monitor.command(name="create")
+@click.argument("query")
+@click.option(
+    "--cadence",
+    "-c",
+    type=click.Choice(list(MONITOR_CADENCES.keys())),
+    default="daily",
+    show_default=True,
+    help="How often to check for changes",
+)
+@click.option("--webhook", help="Webhook URL for event delivery")
+@click.option("--metadata", "metadata_json", help="Metadata as JSON string")
+@click.option("--output-schema", "output_schema_json", help="Output schema as JSON string")
+@click.option("-o", "--output", "output_file", type=click.Path(), help="Save result to JSON file")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def monitor_create(
+    query: str,
+    cadence: str,
+    webhook: str | None,
+    metadata_json: str | None,
+    output_schema_json: str | None,
+    output_file: str | None,
+    output_json: bool,
+):
+    """Create a new monitor to track the web for changes.
+
+    QUERY is a natural language description of what to track.
+
+    Examples:
+
+        parallel-cli monitor create "Track price changes for iPhone 16"
+
+        parallel-cli monitor create "New AI funding announcements" --cadence hourly
+
+        parallel-cli monitor create "SEC filings from Tesla" --webhook https://example.com/hook
+    """
+    try:
+        metadata = json.loads(metadata_json) if metadata_json else None
+        output_schema = json.loads(output_schema_json) if output_schema_json else None
+    except json.JSONDecodeError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Invalid JSON")
+        return
+
+    try:
+        if not output_json:
+            console.print(f"[dim]Creating monitor with cadence={cadence}...[/dim]")
+
+        result = create_monitor(
+            query=query,
+            cadence=cadence,
+            webhook=webhook,
+            metadata=metadata,
+            output_schema=output_schema,
+            source="cli",
+        )
+
+        write_json_output(result, output_file, output_json)
+
+        if not output_json:
+            monitor_id = result.get("monitor_id", "unknown")
+            console.print(f"\n[bold green]Monitor created: {monitor_id}[/bold green]")
+            console.print(f"[dim]Query: {query}[/dim]")
+            console.print(f"[dim]Cadence: {cadence} ({MONITOR_CADENCES[cadence]})[/dim]")
+            if webhook:
+                console.print(f"[dim]Webhook: {webhook}[/dim]")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="list")
+@click.option("--limit", "-n", type=int, help="Maximum number of monitors to return")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def monitor_list(limit: int | None, output_json: bool):
+    """List all monitors.
+
+    Examples:
+
+        parallel-cli monitor list
+
+        parallel-cli monitor list --limit 10 --json
+    """
+    try:
+        result = list_monitors(limit=limit, source="cli")
+
+        if output_json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            if not result:
+                console.print("[yellow]No monitors found.[/yellow]")
+                return
+
+            from rich.table import Table
+
+            table = Table(title=f"Monitors ({len(result)})")
+            table.add_column("ID", style="cyan", no_wrap=True)
+            table.add_column("Query", max_width=50)
+            table.add_column("Cadence", style="green")
+            table.add_column("Status", style="yellow")
+
+            for m in result:
+                table.add_row(
+                    m.get("monitor_id", ""),
+                    (m.get("query", "") or "")[:50],
+                    m.get("cadence", ""),
+                    m.get("status", ""),
+                )
+
+            console.print(table)
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="get")
+@click.argument("monitor_id")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def monitor_get(monitor_id: str, output_json: bool):
+    """Get details of a specific monitor.
+
+    MONITOR_ID is the monitor identifier.
+    """
+    try:
+        result = get_monitor(monitor_id, source="cli")
+
+        if output_json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            console.print(f"[bold]Monitor:[/bold]  {result.get('monitor_id', monitor_id)}")
+            console.print(f"[bold]Query:[/bold]    {result.get('query', '')}")
+            console.print(f"[bold]Cadence:[/bold]  {result.get('cadence', '')}")
+            console.print(f"[bold]Status:[/bold]   {result.get('status', '')}")
+            if result.get("webhook"):
+                console.print(f"[bold]Webhook:[/bold]  {result['webhook']}")
+            if result.get("created_at"):
+                console.print(f"[bold]Created:[/bold]  {result['created_at']}")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="update")
+@click.argument("monitor_id")
+@click.option("--query", "-q", help="Updated query text")
+@click.option("--cadence", "-c", type=click.Choice(list(MONITOR_CADENCES.keys())), help="Updated cadence")
+@click.option("--webhook", help="Updated webhook URL")
+@click.option("--metadata", "metadata_json", help="Updated metadata as JSON string")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def monitor_update(
+    monitor_id: str,
+    query: str | None,
+    cadence: str | None,
+    webhook: str | None,
+    metadata_json: str | None,
+    output_json: bool,
+):
+    """Update an existing monitor.
+
+    MONITOR_ID is the monitor identifier.
+
+    Examples:
+
+        parallel-cli monitor update mon_abc --cadence hourly
+
+        parallel-cli monitor update mon_abc --query "Updated tracking query"
+    """
+    if not any([query, cadence, webhook, metadata_json]):
+        _handle_error(
+            click.UsageError("Provide at least one field to update (--query, --cadence, --webhook, --metadata)"),
+            output_json=output_json,
+            exit_code=EXIT_BAD_INPUT,
+        )
+        return
+
+    try:
+        metadata = json.loads(metadata_json) if metadata_json else None
+    except json.JSONDecodeError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Invalid JSON")
+        return
+
+    try:
+        result = update_monitor(
+            monitor_id=monitor_id,
+            query=query,
+            cadence=cadence,
+            webhook=webhook,
+            metadata=metadata,
+            source="cli",
+        )
+
+        if output_json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            console.print(f"[bold green]Monitor updated: {monitor_id}[/bold green]")
+            if query:
+                console.print(f"[dim]Query: {query}[/dim]")
+            if cadence:
+                console.print(f"[dim]Cadence: {cadence}[/dim]")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="delete")
+@click.argument("monitor_id")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def monitor_delete(monitor_id: str, output_json: bool):
+    """Delete a monitor.
+
+    MONITOR_ID is the monitor identifier.
+    """
+    try:
+        result = delete_monitor(monitor_id, source="cli")
+
+        if output_json:
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            console.print(f"[bold green]Deleted:[/bold green] {monitor_id}")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="events")
+@click.argument("monitor_id")
+@click.option("--lookback", default="10d", show_default=True, help="Lookback period (e.g., 10d, 24h)")
+@click.option("-o", "--output", "output_file", type=click.Path(), help="Save results to JSON file")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def monitor_events(monitor_id: str, lookback: str, output_file: str | None, output_json: bool):
+    """List events for a monitor.
+
+    MONITOR_ID is the monitor identifier.
+
+    Examples:
+
+        parallel-cli monitor events mon_abc
+
+        parallel-cli monitor events mon_abc --lookback 24h --json
+    """
+    try:
+        result = list_monitor_events(monitor_id, lookback_period=lookback, source="cli")
+
+        write_json_output(result, output_file, output_json)
+
+        if not output_json:
+            events = result.get("events", [])
+            if not events:
+                console.print(f"[yellow]No events found for {monitor_id} in the last {lookback}.[/yellow]")
+                return
+
+            from rich.table import Table
+
+            table = Table(title=f"Events for {monitor_id} ({len(events)})")
+            table.add_column("Event ID", style="cyan", no_wrap=True)
+            table.add_column("Type", style="green")
+            table.add_column("Timestamp", style="dim")
+            table.add_column("Summary", max_width=50)
+
+            for ev in events:
+                table.add_row(
+                    ev.get("event_id", ""),
+                    ev.get("type", ""),
+                    ev.get("created_at", ""),
+                    (ev.get("summary", "") or "")[:50],
+                )
+
+            console.print(table)
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="event-group")
+@click.argument("monitor_id")
+@click.argument("event_group_id")
+@click.option("-o", "--output", "output_file", type=click.Path(), help="Save result to JSON file")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def monitor_event_group(monitor_id: str, event_group_id: str, output_file: str | None, output_json: bool):
+    """Get details of an event group.
+
+    MONITOR_ID is the monitor identifier.
+    EVENT_GROUP_ID is the event group identifier.
+    """
+    try:
+        result = get_monitor_event_group(monitor_id, event_group_id, source="cli")
+
+        write_json_output(result, output_file, output_json)
+
+        if not output_json:
+            console.print(f"[bold]Monitor:[/bold]     {monitor_id}")
+            console.print(f"[bold]Event Group:[/bold] {event_group_id}")
+            console.print(f"[bold]Type:[/bold]        {result.get('type', '')}")
+            console.print(f"[bold]Created:[/bold]     {result.get('created_at', '')}")
+            events = result.get("events", [])
+            if events:
+                console.print(f"\n[bold]Events ({len(events)}):[/bold]")
+                for ev in events:
+                    console.print(f"  [cyan]{ev.get('event_id', '')}[/cyan]: {ev.get('summary', '')}")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@monitor.command(name="simulate")
+@click.argument("monitor_id")
+@click.option("--event-type", help="Event type to simulate (e.g., change_detected)")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def monitor_simulate(monitor_id: str, event_type: str | None, output_json: bool):
+    """Simulate an event for webhook testing.
+
+    MONITOR_ID is the monitor identifier.
+
+    Examples:
+
+        parallel-cli monitor simulate mon_abc
+
+        parallel-cli monitor simulate mon_abc --event-type change_detected
+    """
+    try:
+        simulate_monitor_event(monitor_id, event_type=event_type, source="cli")
+
+        if output_json:
+            print(json.dumps({"monitor_id": monitor_id, "simulated": True}, indent=2))
+        else:
+            console.print(f"[bold green]Event simulated for:[/bold green] {monitor_id}")
+            if event_type:
+                console.print(f"[dim]Event type: {event_type}[/dim]")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
 
 
 if __name__ == "__main__":

--- a/parallel_web_tools/core/__init__.py
+++ b/parallel_web_tools/core/__init__.py
@@ -29,6 +29,17 @@ from parallel_web_tools.core.findall import (
     poll_findall,
     run_findall,
 )
+from parallel_web_tools.core.monitor import (
+    MONITOR_CADENCES,
+    create_monitor,
+    delete_monitor,
+    get_monitor,
+    get_monitor_event_group,
+    list_monitor_events,
+    list_monitors,
+    simulate_monitor_event,
+    update_monitor,
+)
 from parallel_web_tools.core.research import (
     RESEARCH_PROCESSORS,
     create_research_task,
@@ -116,6 +127,16 @@ __all__ = [
     "ingest_findall",
     "poll_findall",
     "run_findall",
+    # Monitor
+    "MONITOR_CADENCES",
+    "create_monitor",
+    "delete_monitor",
+    "get_monitor",
+    "get_monitor_event_group",
+    "list_monitor_events",
+    "list_monitors",
+    "simulate_monitor_event",
+    "update_monitor",
     # Result
     "EnrichmentResult",
 ]

--- a/parallel_web_tools/core/monitor.py
+++ b/parallel_web_tools/core/monitor.py
@@ -1,0 +1,293 @@
+"""Monitor: continuously track the web for changes using the Parallel Monitor API.
+
+Monitors let you define natural-language queries that run on a schedule (cadence).
+When changes are detected, events are generated and optionally delivered via webhook.
+
+This module uses httpx directly since the SDK does not yet have high-level
+convenience methods for Monitor endpoints.
+
+The typical workflow is:
+    1. Create a monitor with a query and cadence
+    2. Optionally configure a webhook for real-time notifications
+    3. List events to see detected changes
+    4. Update or delete monitors as needed
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from parallel_web_tools.core.auth import resolve_api_key
+from parallel_web_tools.core.user_agent import ClientSource, get_default_headers
+
+BASE_URL = "https://api.parallel.ai"
+
+# Supported cadences for monitor scheduling
+MONITOR_CADENCES = {
+    "5min": "Every 5 minutes",
+    "15min": "Every 15 minutes",
+    "30min": "Every 30 minutes",
+    "hourly": "Every hour",
+    "daily": "Once per day",
+    "weekly": "Once per week",
+}
+
+# Valid webhook event types
+MONITOR_EVENT_TYPES = [
+    "change_detected",
+    "monitor_error",
+]
+
+
+def _request(
+    method: str,
+    path: str,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+    json: Any | None = None,
+    params: dict[str, Any] | None = None,
+) -> httpx.Response:
+    """Send an authenticated request to the Monitor API.
+
+    Args:
+        method: HTTP method (GET, POST, DELETE).
+        path: API path (e.g., "/v1alpha/monitors").
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+        json: Optional JSON body.
+        params: Optional query parameters.
+
+    Returns:
+        The httpx Response object.
+
+    Raises:
+        httpx.HTTPStatusError: If the response indicates an error.
+    """
+    key = resolve_api_key(api_key)
+    headers = {
+        **get_default_headers(source),
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    url = f"{BASE_URL}{path}"
+
+    response = httpx.request(method, url, headers=headers, json=json, params=params, timeout=30)
+    response.raise_for_status()
+    return response
+
+
+def create_monitor(
+    query: str,
+    cadence: str,
+    webhook: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    output_schema: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """Create a new monitor.
+
+    Args:
+        query: Natural language query describing what to track.
+        cadence: How often to check (e.g., "daily", "hourly").
+        webhook: Optional webhook URL for event delivery.
+        metadata: Optional metadata dict.
+        output_schema: Optional JSON schema for structured output.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with monitor details including monitor_id.
+    """
+    body: dict[str, Any] = {"query": query, "cadence": cadence}
+    if webhook is not None:
+        body["webhook"] = webhook
+    if metadata is not None:
+        body["metadata"] = metadata
+    if output_schema is not None:
+        body["output_schema"] = output_schema
+
+    resp = _request("POST", "/v1alpha/monitors", api_key=api_key, source=source, json=body)
+    return resp.json()
+
+
+def list_monitors(
+    monitor_id: str | None = None,
+    limit: int | None = None,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> list[dict[str, Any]]:
+    """List monitors with optional pagination.
+
+    Args:
+        monitor_id: Cursor for pagination (start after this monitor).
+        limit: Maximum number of monitors to return.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        List of monitor dicts.
+    """
+    params: dict[str, Any] = {}
+    if monitor_id is not None:
+        params["monitor_id"] = monitor_id
+    if limit is not None:
+        params["limit"] = limit
+
+    resp = _request("GET", "/v1alpha/monitors", api_key=api_key, source=source, params=params)
+    data = resp.json()
+    return data.get("monitors", data) if isinstance(data, dict) else data
+
+
+def get_monitor(
+    monitor_id: str,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """Retrieve a single monitor by ID.
+
+    Args:
+        monitor_id: The monitor ID.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with monitor details.
+    """
+    resp = _request("GET", f"/v1alpha/monitors/{monitor_id}", api_key=api_key, source=source)
+    return resp.json()
+
+
+def update_monitor(
+    monitor_id: str,
+    query: str | None = None,
+    cadence: str | None = None,
+    webhook: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """Update an existing monitor.
+
+    Args:
+        monitor_id: The monitor ID.
+        query: Updated query text.
+        cadence: Updated cadence.
+        webhook: Updated webhook URL.
+        metadata: Updated metadata dict.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with updated monitor details.
+    """
+    body: dict[str, Any] = {}
+    if query is not None:
+        body["query"] = query
+    if cadence is not None:
+        body["cadence"] = cadence
+    if webhook is not None:
+        body["webhook"] = webhook
+    if metadata is not None:
+        body["metadata"] = metadata
+
+    resp = _request("POST", f"/v1alpha/monitors/{monitor_id}", api_key=api_key, source=source, json=body)
+    return resp.json()
+
+
+def delete_monitor(
+    monitor_id: str,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """Delete a monitor.
+
+    Args:
+        monitor_id: The monitor ID.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with deletion confirmation.
+    """
+    resp = _request("DELETE", f"/v1alpha/monitors/{monitor_id}", api_key=api_key, source=source)
+    if resp.status_code == 204 or not resp.content:
+        return {"monitor_id": monitor_id, "deleted": True}
+    return resp.json()
+
+
+def list_monitor_events(
+    monitor_id: str,
+    lookback_period: str = "10d",
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """List events for a monitor.
+
+    Args:
+        monitor_id: The monitor ID.
+        lookback_period: How far back to look (e.g., "10d", "24h").
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with events list.
+    """
+    params = {"lookback_period": lookback_period}
+    resp = _request("GET", f"/v1alpha/monitors/{monitor_id}/events", api_key=api_key, source=source, params=params)
+    return resp.json()
+
+
+def get_monitor_event_group(
+    monitor_id: str,
+    event_group_id: str,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """Retrieve a specific event group.
+
+    Args:
+        monitor_id: The monitor ID.
+        event_group_id: The event group ID.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with event group details.
+    """
+    resp = _request(
+        "GET",
+        f"/v1alpha/monitors/{monitor_id}/event_groups/{event_group_id}",
+        api_key=api_key,
+        source=source,
+    )
+    return resp.json()
+
+
+def simulate_monitor_event(
+    monitor_id: str,
+    event_type: str | None = None,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> None:
+    """Simulate an event for webhook testing.
+
+    Args:
+        monitor_id: The monitor ID.
+        event_type: Optional event type to simulate.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+    """
+    body: dict[str, Any] = {}
+    if event_type is not None:
+        body["event_type"] = event_type
+
+    _request(
+        "POST",
+        f"/v1alpha/monitors/{monitor_id}/simulate_event",
+        api_key=api_key,
+        source=source,
+        json=body if body else None,
+    )

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,769 @@
+"""Tests for the Monitor web tracking functionality."""
+
+import json
+from unittest import mock
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from parallel_web_tools.cli.commands import main
+from parallel_web_tools.core.monitor import (
+    BASE_URL,
+    MONITOR_CADENCES,
+    MONITOR_EVENT_TYPES,
+    _request,
+    create_monitor,
+    delete_monitor,
+    get_monitor,
+    get_monitor_event_group,
+    list_monitor_events,
+    list_monitors,
+    simulate_monitor_event,
+    update_monitor,
+)
+
+
+@pytest.fixture
+def runner():
+    """Create a CLI test runner."""
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_httpx():
+    """Mock httpx.request for monitor API calls."""
+    with mock.patch("parallel_web_tools.core.monitor.httpx") as m:
+        yield m
+
+
+@pytest.fixture
+def mock_resolve_api_key():
+    """Mock resolve_api_key to return a test key."""
+    with mock.patch("parallel_web_tools.core.monitor.resolve_api_key", return_value="test-key"):
+        yield
+
+
+def _make_response(status_code=200, json_data=None):
+    """Helper to build a mock httpx Response."""
+    resp = mock.MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.content = json.dumps(json_data).encode() if json_data is not None else b""
+    resp.json.return_value = json_data if json_data is not None else {}
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+# =============================================================================
+# Constants Tests
+# =============================================================================
+
+
+class TestConstants:
+    """Tests for module-level constants."""
+
+    def test_cadences_exist(self):
+        assert "daily" in MONITOR_CADENCES
+        assert "hourly" in MONITOR_CADENCES
+        assert len(MONITOR_CADENCES) > 0
+
+    def test_event_types_exist(self):
+        assert "change_detected" in MONITOR_EVENT_TYPES
+        assert len(MONITOR_EVENT_TYPES) > 0
+
+    def test_base_url(self):
+        assert BASE_URL == "https://api.parallel.ai"
+
+
+# =============================================================================
+# Core Function Tests
+# =============================================================================
+
+
+class TestRequest:
+    """Tests for the _request helper."""
+
+    def test_sends_auth_header(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"ok": True})
+
+        _request("GET", "/v1alpha/monitors")
+
+        call_kwargs = mock_httpx.request.call_args
+        headers = call_kwargs.kwargs.get("headers") or call_kwargs[1].get("headers")
+        assert headers["Authorization"] == "Bearer test-key"
+
+    def test_uses_correct_url(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {})
+
+        _request("GET", "/v1alpha/monitors")
+
+        call_args = mock_httpx.request.call_args
+        assert call_args[0][0] == "GET"
+        assert call_args[0][1] == f"{BASE_URL}/v1alpha/monitors"
+
+    def test_passes_json_body(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {})
+        body = {"query": "test", "cadence": "daily"}
+
+        _request("POST", "/v1alpha/monitors", json=body)
+
+        call_kwargs = mock_httpx.request.call_args
+        assert call_kwargs.kwargs.get("json") == body
+
+    def test_passes_query_params(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {})
+
+        _request("GET", "/v1alpha/monitors", params={"limit": 10})
+
+        call_kwargs = mock_httpx.request.call_args
+        assert call_kwargs.kwargs.get("params") == {"limit": 10}
+
+    def test_raises_on_http_error(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Not Found", request=mock.MagicMock(), response=mock.MagicMock()
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            _request("GET", "/v1alpha/monitors/bad_id")
+
+
+class TestCreateMonitor:
+    """Tests for create_monitor."""
+
+    def test_basic_create(self, mock_httpx, mock_resolve_api_key):
+        expected = {"monitor_id": "mon_123", "query": "track AI news", "cadence": "daily"}
+        mock_httpx.request.return_value = _make_response(200, expected)
+
+        result = create_monitor("track AI news", "daily")
+
+        assert result["monitor_id"] == "mon_123"
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert body["query"] == "track AI news"
+        assert body["cadence"] == "daily"
+
+    def test_create_with_all_options(self, mock_httpx, mock_resolve_api_key):
+        expected = {"monitor_id": "mon_456"}
+        mock_httpx.request.return_value = _make_response(200, expected)
+
+        result = create_monitor(
+            "track stuff",
+            "hourly",
+            webhook="https://hook.example.com",
+            metadata={"project": "test"},
+            output_schema={"type": "object"},
+        )
+
+        assert result["monitor_id"] == "mon_456"
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert body["webhook"] == "https://hook.example.com"
+        assert body["metadata"] == {"project": "test"}
+        assert body["output_schema"] == {"type": "object"}
+
+    def test_create_omits_none_fields(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"monitor_id": "mon_x"})
+
+        create_monitor("query", "daily")
+
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert "webhook" not in body
+        assert "metadata" not in body
+        assert "output_schema" not in body
+
+
+class TestListMonitors:
+    """Tests for list_monitors."""
+
+    def test_list_basic(self, mock_httpx, mock_resolve_api_key):
+        monitors = [{"monitor_id": "mon_1"}, {"monitor_id": "mon_2"}]
+        mock_httpx.request.return_value = _make_response(200, {"monitors": monitors})
+
+        result = list_monitors()
+
+        assert len(result) == 2
+        assert result[0]["monitor_id"] == "mon_1"
+
+    def test_list_with_limit(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"monitors": []})
+
+        list_monitors(limit=5)
+
+        call_kwargs = mock_httpx.request.call_args
+        assert call_kwargs.kwargs.get("params") == {"limit": 5}
+
+    def test_list_with_cursor(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"monitors": []})
+
+        list_monitors(monitor_id="mon_cursor")
+
+        call_kwargs = mock_httpx.request.call_args
+        assert call_kwargs.kwargs.get("params")["monitor_id"] == "mon_cursor"
+
+    def test_list_handles_array_response(self, mock_httpx, mock_resolve_api_key):
+        monitors = [{"monitor_id": "mon_1"}]
+        mock_httpx.request.return_value = _make_response(200, monitors)
+
+        result = list_monitors()
+
+        assert len(result) == 1
+
+
+class TestGetMonitor:
+    """Tests for get_monitor."""
+
+    def test_get_by_id(self, mock_httpx, mock_resolve_api_key):
+        expected = {"monitor_id": "mon_abc", "query": "test", "cadence": "daily"}
+        mock_httpx.request.return_value = _make_response(200, expected)
+
+        result = get_monitor("mon_abc")
+
+        assert result["monitor_id"] == "mon_abc"
+        call_args = mock_httpx.request.call_args
+        assert "/v1alpha/monitors/mon_abc" in call_args[0][1]
+
+
+class TestUpdateMonitor:
+    """Tests for update_monitor."""
+
+    def test_update_query(self, mock_httpx, mock_resolve_api_key):
+        expected = {"monitor_id": "mon_abc", "query": "new query"}
+        mock_httpx.request.return_value = _make_response(200, expected)
+
+        result = update_monitor("mon_abc", query="new query")
+
+        assert result["query"] == "new query"
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert body["query"] == "new query"
+
+    def test_update_cadence(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"monitor_id": "mon_abc"})
+
+        update_monitor("mon_abc", cadence="hourly")
+
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert body["cadence"] == "hourly"
+
+    def test_update_omits_none_fields(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"monitor_id": "mon_abc"})
+
+        update_monitor("mon_abc", query="only query")
+
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert "cadence" not in body
+        assert "webhook" not in body
+
+
+class TestDeleteMonitor:
+    """Tests for delete_monitor."""
+
+    def test_delete(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"monitor_id": "mon_del", "deleted": True})
+
+        result = delete_monitor("mon_del")
+
+        assert result["deleted"] is True
+        call_args = mock_httpx.request.call_args
+        assert call_args[0][0] == "DELETE"
+
+    def test_delete_204_no_content(self, mock_httpx, mock_resolve_api_key):
+        resp = _make_response(204)
+        resp.content = b""
+        mock_httpx.request.return_value = resp
+
+        result = delete_monitor("mon_del")
+
+        assert result["monitor_id"] == "mon_del"
+        assert result["deleted"] is True
+
+
+class TestListMonitorEvents:
+    """Tests for list_monitor_events."""
+
+    def test_list_events_default_lookback(self, mock_httpx, mock_resolve_api_key):
+        expected = {"events": [{"event_id": "ev_1"}]}
+        mock_httpx.request.return_value = _make_response(200, expected)
+
+        result = list_monitor_events("mon_abc")
+
+        assert len(result["events"]) == 1
+        call_kwargs = mock_httpx.request.call_args
+        assert call_kwargs.kwargs.get("params") == {"lookback_period": "10d"}
+
+    def test_list_events_custom_lookback(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {"events": []})
+
+        list_monitor_events("mon_abc", lookback_period="24h")
+
+        call_kwargs = mock_httpx.request.call_args
+        assert call_kwargs.kwargs.get("params") == {"lookback_period": "24h"}
+
+
+class TestGetMonitorEventGroup:
+    """Tests for get_monitor_event_group."""
+
+    def test_get_event_group(self, mock_httpx, mock_resolve_api_key):
+        expected = {"event_group_id": "eg_123", "type": "change_detected"}
+        mock_httpx.request.return_value = _make_response(200, expected)
+
+        result = get_monitor_event_group("mon_abc", "eg_123")
+
+        assert result["event_group_id"] == "eg_123"
+        call_args = mock_httpx.request.call_args
+        assert "/v1alpha/monitors/mon_abc/event_groups/eg_123" in call_args[0][1]
+
+
+class TestSimulateMonitorEvent:
+    """Tests for simulate_monitor_event."""
+
+    def test_simulate_basic(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {})
+
+        simulate_monitor_event("mon_abc")
+
+        call_args = mock_httpx.request.call_args
+        assert call_args[0][0] == "POST"
+        assert "/simulate_event" in call_args[0][1]
+
+    def test_simulate_with_event_type(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {})
+
+        simulate_monitor_event("mon_abc", event_type="change_detected")
+
+        call_kwargs = mock_httpx.request.call_args
+        body = call_kwargs.kwargs.get("json")
+        assert body["event_type"] == "change_detected"
+
+    def test_simulate_returns_none(self, mock_httpx, mock_resolve_api_key):
+        mock_httpx.request.return_value = _make_response(200, {})
+
+        result = simulate_monitor_event("mon_abc")
+
+        assert result is None
+
+
+# =============================================================================
+# CLI Command Tests
+# =============================================================================
+
+
+class TestMonitorGroup:
+    """Tests for the monitor command group."""
+
+    def test_monitor_help(self, runner):
+        result = runner.invoke(main, ["monitor", "--help"])
+        assert result.exit_code == 0
+        assert "create" in result.output
+        assert "list" in result.output
+        assert "get" in result.output
+        assert "update" in result.output
+        assert "delete" in result.output
+        assert "events" in result.output
+        assert "event-group" in result.output
+        assert "simulate" in result.output
+
+    def test_monitor_in_main_help(self, runner):
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "monitor" in result.output
+
+
+class TestMonitorCreateCommand:
+    """Tests for the monitor create CLI command."""
+
+    def test_create_help(self, runner):
+        result = runner.invoke(main, ["monitor", "create", "--help"])
+        assert result.exit_code == 0
+        assert "--cadence" in result.output
+        assert "--webhook" in result.output
+        assert "--json" in result.output
+
+    def test_create_no_query(self, runner):
+        result = runner.invoke(main, ["monitor", "create"])
+        assert result.exit_code != 0
+
+    def test_create_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.return_value = {
+                "monitor_id": "mon_test",
+                "query": "track AI news",
+                "cadence": "daily",
+            }
+
+            result = runner.invoke(main, ["monitor", "create", "track AI news"])
+
+            assert result.exit_code == 0
+            assert "mon_test" in result.output
+            mock_create.assert_called_once()
+
+    def test_create_with_cadence(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.return_value = {"monitor_id": "mon_hr"}
+
+            result = runner.invoke(main, ["monitor", "create", "track stuff", "--cadence", "hourly"])
+
+            assert result.exit_code == 0
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["cadence"] == "hourly"
+
+    def test_create_json_output(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.return_value = {
+                "monitor_id": "mon_json",
+                "query": "test",
+                "cadence": "daily",
+            }
+
+            result = runner.invoke(main, ["monitor", "create", "test", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["monitor_id"] == "mon_json"
+
+    def test_create_with_webhook(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.return_value = {"monitor_id": "mon_wh"}
+
+            result = runner.invoke(main, ["monitor", "create", "test", "--webhook", "https://hook.example.com"])
+
+            assert result.exit_code == 0
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["webhook"] == "https://hook.example.com"
+
+    def test_create_invalid_metadata_json(self, runner):
+        result = runner.invoke(main, ["monitor", "create", "test", "--metadata", "not-json"])
+        assert result.exit_code != 0
+
+    def test_create_saves_to_output_file(self, runner, tmp_path):
+        output_file = tmp_path / "monitor.json"
+
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.return_value = {"monitor_id": "mon_file", "query": "test", "cadence": "daily"}
+
+            result = runner.invoke(main, ["monitor", "create", "test", "-o", str(output_file)])
+
+            assert result.exit_code == 0
+            assert output_file.exists()
+            data = json.loads(output_file.read_text())
+            assert data["monitor_id"] == "mon_file"
+
+
+class TestMonitorListCommand:
+    """Tests for the monitor list CLI command."""
+
+    def test_list_help(self, runner):
+        result = runner.invoke(main, ["monitor", "list", "--help"])
+        assert result.exit_code == 0
+        assert "--limit" in result.output
+
+    def test_list_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitors") as mock_list:
+            mock_list.return_value = [
+                {"monitor_id": "mon_1", "query": "test", "cadence": "daily", "status": "active"},
+            ]
+
+            result = runner.invoke(main, ["monitor", "list"])
+
+            assert result.exit_code == 0
+            assert "mon_1" in result.output
+
+    def test_list_empty(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitors") as mock_list:
+            mock_list.return_value = []
+
+            result = runner.invoke(main, ["monitor", "list"])
+
+            assert result.exit_code == 0
+            assert "No monitors found" in result.output
+
+    def test_list_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitors") as mock_list:
+            monitors = [{"monitor_id": "mon_1"}, {"monitor_id": "mon_2"}]
+            mock_list.return_value = monitors
+
+            result = runner.invoke(main, ["monitor", "list", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert len(output) == 2
+
+    def test_list_with_limit(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitors") as mock_list:
+            mock_list.return_value = []
+
+            runner.invoke(main, ["monitor", "list", "--limit", "5"])
+
+            call_kwargs = mock_list.call_args.kwargs
+            assert call_kwargs["limit"] == 5
+
+
+class TestMonitorGetCommand:
+    """Tests for the monitor get CLI command."""
+
+    def test_get_help(self, runner):
+        result = runner.invoke(main, ["monitor", "get", "--help"])
+        assert result.exit_code == 0
+        assert "MONITOR_ID" in result.output
+
+    def test_get_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.get_monitor") as mock_get:
+            mock_get.return_value = {
+                "monitor_id": "mon_abc",
+                "query": "track news",
+                "cadence": "daily",
+                "status": "active",
+            }
+
+            result = runner.invoke(main, ["monitor", "get", "mon_abc"])
+
+            assert result.exit_code == 0
+            assert "mon_abc" in result.output
+            assert "track news" in result.output
+
+    def test_get_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.get_monitor") as mock_get:
+            mock_get.return_value = {"monitor_id": "mon_abc", "query": "test"}
+
+            result = runner.invoke(main, ["monitor", "get", "mon_abc", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["monitor_id"] == "mon_abc"
+
+
+class TestMonitorUpdateCommand:
+    """Tests for the monitor update CLI command."""
+
+    def test_update_help(self, runner):
+        result = runner.invoke(main, ["monitor", "update", "--help"])
+        assert result.exit_code == 0
+        assert "--query" in result.output
+        assert "--cadence" in result.output
+
+    def test_update_no_fields(self, runner):
+        result = runner.invoke(main, ["monitor", "update", "mon_abc"])
+        assert result.exit_code != 0
+
+    def test_update_query(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.update_monitor") as mock_update:
+            mock_update.return_value = {"monitor_id": "mon_abc", "query": "new query"}
+
+            result = runner.invoke(main, ["monitor", "update", "mon_abc", "--query", "new query"])
+
+            assert result.exit_code == 0
+            assert "updated" in result.output.lower()
+
+    def test_update_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.update_monitor") as mock_update:
+            mock_update.return_value = {"monitor_id": "mon_abc"}
+
+            result = runner.invoke(main, ["monitor", "update", "mon_abc", "--cadence", "hourly", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["monitor_id"] == "mon_abc"
+
+
+class TestMonitorDeleteCommand:
+    """Tests for the monitor delete CLI command."""
+
+    def test_delete_help(self, runner):
+        result = runner.invoke(main, ["monitor", "delete", "--help"])
+        assert result.exit_code == 0
+
+    def test_delete_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.delete_monitor") as mock_del:
+            mock_del.return_value = {"monitor_id": "mon_abc", "deleted": True}
+
+            result = runner.invoke(main, ["monitor", "delete", "mon_abc"])
+
+            assert result.exit_code == 0
+            assert "mon_abc" in result.output
+
+    def test_delete_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.delete_monitor") as mock_del:
+            mock_del.return_value = {"monitor_id": "mon_abc", "deleted": True}
+
+            result = runner.invoke(main, ["monitor", "delete", "mon_abc", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["deleted"] is True
+
+
+class TestMonitorEventsCommand:
+    """Tests for the monitor events CLI command."""
+
+    def test_events_help(self, runner):
+        result = runner.invoke(main, ["monitor", "events", "--help"])
+        assert result.exit_code == 0
+        assert "--lookback" in result.output
+
+    def test_events_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitor_events") as mock_events:
+            mock_events.return_value = {
+                "events": [
+                    {
+                        "event_id": "ev_1",
+                        "type": "change_detected",
+                        "created_at": "2026-01-01",
+                        "summary": "Price changed",
+                    },
+                ]
+            }
+
+            result = runner.invoke(main, ["monitor", "events", "mon_abc"])
+
+            assert result.exit_code == 0
+            assert "ev_1" in result.output
+
+    def test_events_empty(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitor_events") as mock_events:
+            mock_events.return_value = {"events": []}
+
+            result = runner.invoke(main, ["monitor", "events", "mon_abc"])
+
+            assert result.exit_code == 0
+            assert "No events found" in result.output
+
+    def test_events_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitor_events") as mock_events:
+            mock_events.return_value = {"events": [{"event_id": "ev_1"}]}
+
+            result = runner.invoke(main, ["monitor", "events", "mon_abc", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert len(output["events"]) == 1
+
+    def test_events_custom_lookback(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitor_events") as mock_events:
+            mock_events.return_value = {"events": []}
+
+            runner.invoke(main, ["monitor", "events", "mon_abc", "--lookback", "24h"])
+
+            call_kwargs = mock_events.call_args.kwargs
+            assert call_kwargs["lookback_period"] == "24h"
+
+    def test_events_saves_to_file(self, runner, tmp_path):
+        output_file = tmp_path / "events.json"
+
+        with mock.patch("parallel_web_tools.cli.commands.list_monitor_events") as mock_events:
+            mock_events.return_value = {"events": [{"event_id": "ev_1"}]}
+
+            result = runner.invoke(main, ["monitor", "events", "mon_abc", "-o", str(output_file)])
+
+            assert result.exit_code == 0
+            assert output_file.exists()
+
+
+class TestMonitorEventGroupCommand:
+    """Tests for the monitor event-group CLI command."""
+
+    def test_event_group_help(self, runner):
+        result = runner.invoke(main, ["monitor", "event-group", "--help"])
+        assert result.exit_code == 0
+
+    def test_event_group_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.get_monitor_event_group") as mock_eg:
+            mock_eg.return_value = {
+                "event_group_id": "eg_123",
+                "type": "change_detected",
+                "created_at": "2026-01-01",
+                "events": [],
+            }
+
+            result = runner.invoke(main, ["monitor", "event-group", "mon_abc", "eg_123"])
+
+            assert result.exit_code == 0
+            assert "eg_123" in result.output
+
+    def test_event_group_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.get_monitor_event_group") as mock_eg:
+            mock_eg.return_value = {"event_group_id": "eg_123"}
+
+            result = runner.invoke(main, ["monitor", "event-group", "mon_abc", "eg_123", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["event_group_id"] == "eg_123"
+
+
+class TestMonitorSimulateCommand:
+    """Tests for the monitor simulate CLI command."""
+
+    def test_simulate_help(self, runner):
+        result = runner.invoke(main, ["monitor", "simulate", "--help"])
+        assert result.exit_code == 0
+        assert "--event-type" in result.output
+
+    def test_simulate_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.simulate_monitor_event") as mock_sim:
+            mock_sim.return_value = None
+
+            result = runner.invoke(main, ["monitor", "simulate", "mon_abc"])
+
+            assert result.exit_code == 0
+            assert "simulated" in result.output.lower()
+
+    def test_simulate_with_event_type(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.simulate_monitor_event") as mock_sim:
+            mock_sim.return_value = None
+
+            result = runner.invoke(main, ["monitor", "simulate", "mon_abc", "--event-type", "change_detected"])
+
+            assert result.exit_code == 0
+            call_kwargs = mock_sim.call_args.kwargs
+            assert call_kwargs["event_type"] == "change_detected"
+
+    def test_simulate_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.simulate_monitor_event") as mock_sim:
+            mock_sim.return_value = None
+
+            result = runner.invoke(main, ["monitor", "simulate", "mon_abc", "--json"])
+
+            assert result.exit_code == 0
+            output = json.loads(result.output)
+            assert output["simulated"] is True
+
+
+class TestMonitorErrorHandling:
+    """Tests for error handling across monitor commands."""
+
+    def test_create_api_error(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.side_effect = Exception("API error")
+
+            result = runner.invoke(main, ["monitor", "create", "test"])
+
+            assert result.exit_code != 0
+
+    def test_create_api_error_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.create_monitor") as mock_create:
+            mock_create.side_effect = Exception("API error")
+
+            result = runner.invoke(main, ["monitor", "create", "test", "--json"])
+
+            assert result.exit_code != 0
+            output = json.loads(result.output)
+            assert "error" in output
+
+    def test_get_api_error(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.get_monitor") as mock_get:
+            mock_get.side_effect = Exception("Not found")
+
+            result = runner.invoke(main, ["monitor", "get", "mon_bad"])
+
+            assert result.exit_code != 0
+
+    def test_list_api_error(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.list_monitors") as mock_list:
+            mock_list.side_effect = Exception("Unauthorized")
+
+            result = runner.invoke(main, ["monitor", "list"])
+
+            assert result.exit_code != 0


### PR DESCRIPTION
## Summary

- Add `parallel-cli monitor` command group with 8 subcommands for the Parallel Monitor API (v1alpha)
- Create `core/monitor.py` with httpx-based API client (SDK lacks high-level monitor methods)
- Supports full CRUD: create, list, get, update, delete monitors, plus events listing, event group retrieval, and webhook simulation

## Commands

```
parallel-cli monitor create QUERY --cadence daily [--webhook URL] [--metadata JSON] [--output-schema JSON] [--json] [-o FILE]
parallel-cli monitor list [--limit N] [--json]
parallel-cli monitor get MONITOR_ID [--json]
parallel-cli monitor update MONITOR_ID [--query Q] [--cadence C] [--webhook URL] [--metadata JSON] [--json]
parallel-cli monitor delete MONITOR_ID [--json]
parallel-cli monitor events MONITOR_ID [--lookback PERIOD] [--json] [-o FILE]
parallel-cli monitor event-group MONITOR_ID EVENT_GROUP_ID [--json] [-o FILE]
parallel-cli monitor simulate MONITOR_ID [--event-type TYPE] [--json]
```

## Test plan

- [x] 69 unit tests covering all core functions and CLI commands
- [x] Existing 75 findall tests still pass (144 total)
- [x] `parallel-cli monitor --help` shows all 8 subcommands
- [x] `parallel-cli monitor create --help` shows all options with cadence choices
- [x] `parallel-cli monitor list --json` returns real monitors from live API
- [x] All pre-commit hooks pass (ruff check, ruff format, pyrefly)