### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-web-cli",
-  "version": "0.0.15-rc.1",
+  "version": "0.1.0",
   "description": "CLI for the Parallel API — web search, data enrichment, and monitoring",
   "homepage": "https://github.com/parallel-web/parallel-web-tools",
   "repository": {

--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -27,7 +27,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.0.15rc1"
+__version__ = "0.1.0"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.0.15rc1
+parallel-web-tools>=0.1.0
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.0.15rc1"
+version = "0.1.0"
 description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,7 +234,7 @@ class TestMainCLI:
         """Should show version."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.0.15rc1" in result.output
+        assert "0.1.0" in result.output
 
 
 class TestAuthCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.0.15rc1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version to `0.1.0` across all version files
- First minor release — all core Parallel APIs now have CLI coverage:
  - **Search** (`search`)
  - **Extract** (`extract` / `fetch`)
  - **Task API / Enrichment** (`enrich run/plan/suggest/status/poll/deploy`)
  - **Deep Research** (`research run/status/poll/processors`)
  - **FindAll** (`findall run/ingest/status/poll/result/cancel`)
  - **Monitor** (`monitor create/list/get/update/delete/events/event-group/simulate`)

## Changes since v0.0.14
- feat: add npm wrapper package for parallel-cli (#39)
- feat: add Monitor API support to CLI for web change tracking (#37)
- feat: add FindAll CLI command for web-scale entity discovery (#36)
- fix: produce clean parseable JSON in --json mode and add --json/--output to enrich run (#35)
- feat: add JSON source type to enrichment pipeline (#34)
- docs: update README for Python 3.10+ and research command (#33)
- fix: slim down standalone CLI binary by only bundling cli extras (#32)
- docs: add npm/package.json to version update checklist

## Test plan
- [ ] CI passes
- [ ] After merge, create GitHub release tagged `v0.1.0`
- [ ] Verify binary builds and PyPI publish