### PR TITLE
feat: automated release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,67 @@
+name: Auto Release
+
+# Triggers when a version bump commit lands on main (from a merged release PR)
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      version: ${{ steps.check.outputs.version }}
+      tag: ${{ steps.check.outputs.tag }}
+      is_prerelease: ${{ steps.check.outputs.is_prerelease }}
+    steps:
+      - name: Check if this is a version bump commit
+        id: check
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" =~ ^chore:\ bump\ version\ to\ (.+)$ ]]; then
+            VERSION="${BASH_REMATCH[1]}"
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+            if [[ "$VERSION" =~ rc ]]; then
+              echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            fi
+            echo "Detected release: $VERSION"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "Not a version bump commit, skipping."
+          fi
+
+  create-release:
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check tag doesn't already exist
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ needs.check.outputs.tag }}$"; then
+            echo "Tag ${{ needs.check.outputs.tag }} already exists!"
+            exit 1
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [[ "${{ needs.check.outputs.is_prerelease }}" == "true" ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+
+          gh release create "${{ needs.check.outputs.tag }}" \
+            --target "${{ github.sha }}" \
+            --title "${{ needs.check.outputs.tag }}" \
+            --generate-notes \
+            $PRERELEASE_FLAG

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,34 @@ Instructions for releasing and maintaining the parallel-web-tools package.
 
 ## Release Process
 
-### 1. Update Version
+### Quick Release (Recommended)
+
+From the `main` branch with a clean working tree:
+
+```bash
+# Release candidate (most common)
+./scripts/release.sh rc
+
+# Promote RC to stable
+./scripts/release.sh stable
+
+# Explicit version
+./scripts/release.sh 0.2.0
+```
+
+This script will:
+1. Calculate the next version
+2. Update all 5 version files
+3. Create a `release/vX.Y.Z` branch
+4. Commit, push, and open a PR
+
+After you merge the PR, everything else is automated:
+- `auto-release.yml` detects the version bump commit and creates a GitHub Release + tag
+- `release.yml` builds standalone binaries for all platforms
+- `publish.yml` publishes to PyPI
+- npm publish is handled by the release workflow
+
+### Manual Version Update (if needed)
 
 Update the version in these places:
 - `pyproject.toml`: `version = "X.Y.Z"`
@@ -13,18 +40,10 @@ Update the version in these places:
 - `parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt`: `parallel-web-tools>=X.Y.Z`
 - `npm/package.json`: `"version": "X.Y.Z"` (use semver pre-release format for RCs, e.g. `"X.Y.Z-rc.1"`)
 
-### 2. Create a GitHub Release
+Then commit with the message `chore: bump version to X.Y.Z` — the auto-release workflow
+will detect it and create the release.
 
-1. Go to **Releases** → **Create new release**
-2. Create a new tag matching the version (e.g., `v0.2.0`)
-3. Add release notes describing changes
-4. Click **Publish release**
-
-This triggers two workflows:
-- **release.yml**: Builds standalone binaries for all platforms
-- **publish.yml**: Publishes to PyPI
-
-### 3. Verify the Release
+### Verify the Release
 
 After the workflows complete:
 
@@ -145,6 +164,7 @@ twine yank parallel-web-tools==0.0.1
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
 | `ci.yml` | Push to main, PRs | Run tests and type checking |
+| `auto-release.yml` | Push to main (version bump commits) | Create tag + GitHub Release |
 | `release.yml` | Release created | Build binaries for all platforms |
 | `publish.yml` | Release published | Publish to PyPI |
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Release script for parallel-web-tools
+# Usage:
+#   ./scripts/release.sh rc       # bump to next RC (0.1.0rc1 -> 0.1.0rc2, or 0.1.0 -> 0.2.0rc1)
+#   ./scripts/release.sh stable   # promote current RC to stable (0.1.0rc2 -> 0.1.0)
+#   ./scripts/release.sh 0.2.0    # set an explicit version
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Helpers ---
+
+die() { echo "error: $*" >&2; exit 1; }
+
+get_current_version() {
+    grep '^version = ' "$PROJECT_ROOT/pyproject.toml" | sed 's/version = "\(.*\)"/\1/'
+}
+
+# Convert Python version (0.1.0rc1) to npm semver (0.1.0-rc.1)
+to_npm_version() {
+    local v="$1"
+    if [[ "$v" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}-rc.${BASH_REMATCH[2]}"
+    else
+        echo "$v"
+    fi
+}
+
+calculate_next_version() {
+    local current="$1"
+    local bump_type="$2"
+
+    case "$bump_type" in
+        rc)
+            if [[ "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)rc([0-9]+)$ ]]; then
+                # Already an RC: increment RC number
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local patch="${BASH_REMATCH[3]}"
+                local rc="${BASH_REMATCH[4]}"
+                echo "${major}.${minor}.${patch}rc$((rc + 1))"
+            elif [[ "$current" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                # Stable: bump minor, start RC1
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local patch="${BASH_REMATCH[3]}"
+                echo "${major}.$((minor + 1)).${patch}rc1"
+            else
+                die "cannot parse version: $current"
+            fi
+            ;;
+        stable)
+            if [[ "$current" =~ ^([0-9]+\.[0-9]+\.[0-9]+)rc[0-9]+$ ]]; then
+                echo "${BASH_REMATCH[1]}"
+            else
+                die "current version ($current) is not an RC — nothing to promote"
+            fi
+            ;;
+        *)
+            # Explicit version provided
+            if [[ "$bump_type" =~ ^[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?$ ]]; then
+                echo "$bump_type"
+            else
+                die "invalid version format: $bump_type (expected X.Y.Z or X.Y.Zrc#)"
+            fi
+            ;;
+    esac
+}
+
+update_version_files() {
+    local new_version="$1"
+    local npm_version
+    npm_version="$(to_npm_version "$new_version")"
+
+    echo "updating versions to $new_version (npm: $npm_version)"
+
+    # 1. pyproject.toml
+    sed -i '' "s/^version = \".*\"/version = \"$new_version\"/" "$PROJECT_ROOT/pyproject.toml"
+
+    # 2. parallel_web_tools/__init__.py
+    sed -i '' "s/__version__ = \".*\"/__version__ = \"$new_version\"/" "$PROJECT_ROOT/parallel_web_tools/__init__.py"
+
+    # 3. tests/test_cli.py — update the version assertion
+    sed -i '' "s/assert \"[0-9][^\"]*\" in result.output/assert \"$new_version\" in result.output/" "$PROJECT_ROOT/tests/test_cli.py"
+
+    # 4. bigquery cloud function requirements.txt
+    sed -i '' "s/parallel-web-tools>=.*/parallel-web-tools>=$new_version/" \
+        "$PROJECT_ROOT/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt"
+
+    # 5. npm/package.json
+    sed -i '' "s/\"version\": \".*\"/\"version\": \"$npm_version\"/" "$PROJECT_ROOT/npm/package.json"
+}
+
+# --- Main ---
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: ./scripts/release.sh <rc|stable|X.Y.Z>"
+    echo ""
+    echo "  rc       bump to next release candidate"
+    echo "  stable   promote current RC to stable"
+    echo "  X.Y.Z    set explicit version"
+    exit 1
+fi
+
+BUMP_TYPE="$1"
+CURRENT_VERSION="$(get_current_version)"
+NEW_VERSION="$(calculate_next_version "$CURRENT_VERSION" "$BUMP_TYPE")"
+NPM_VERSION="$(to_npm_version "$NEW_VERSION")"
+
+# Determine if this is a prerelease
+IS_PRERELEASE=false
+if [[ "$NEW_VERSION" =~ rc ]]; then
+    IS_PRERELEASE=true
+fi
+
+echo ""
+echo "  current version:  $CURRENT_VERSION"
+echo "  new version:      $NEW_VERSION (npm: $NPM_VERSION)"
+echo "  tag:              v$NEW_VERSION"
+echo "  prerelease:       $IS_PRERELEASE"
+echo ""
+
+# Safety checks
+if [[ -n "$(git status --porcelain)" ]]; then
+    die "working tree is not clean — commit or stash changes first"
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ "$CURRENT_BRANCH" != "main" ]]; then
+    die "must be on main branch (currently on $CURRENT_BRANCH)"
+fi
+
+# Check if tag already exists
+if git rev-parse "v$NEW_VERSION" >/dev/null 2>&1; then
+    die "tag v$NEW_VERSION already exists"
+fi
+
+# Confirm
+read -r -p "proceed? [y/N] " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo "aborted."
+    exit 0
+fi
+
+# Update files
+update_version_files "$NEW_VERSION"
+
+# Create branch, commit, push, and open PR
+BRANCH="release/v$NEW_VERSION"
+git checkout -b "$BRANCH"
+git add \
+    pyproject.toml \
+    parallel_web_tools/__init__.py \
+    tests/test_cli.py \
+    parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt \
+    npm/package.json
+
+git commit -m "chore: bump version to $NEW_VERSION"
+
+echo ""
+echo "pushing branch and creating PR..."
+git push -u origin "$BRANCH"
+
+PRERELEASE_NOTE=""
+if [[ "$IS_PRERELEASE" == "true" ]]; then
+    PRERELEASE_NOTE=" (pre-release)"
+fi
+
+gh pr create \
+    --title "chore: bump version to $NEW_VERSION" \
+    --body "$(cat <<EOF
+## Release $NEW_VERSION${PRERELEASE_NOTE}
+
+Bumps version from $CURRENT_VERSION to $NEW_VERSION.
+
+When this PR is merged to main, the release workflow will automatically:
+- Create tag \`v$NEW_VERSION\`
+- Create a GitHub Release with auto-generated notes
+- Build binaries for all platforms
+- Publish to PyPI
+- Publish to npm
+EOF
+)"
+
+echo ""
+echo "done! merge the PR to trigger the release."


### PR DESCRIPTION
## Summary

- Adds `scripts/release.sh` — a one-command release script that bumps all 5 version files, creates a branch, commits, pushes, and opens a PR
- Adds `auto-release.yml` workflow that detects version bump commits on main and automatically creates a GitHub Release + tag
- Updates MAINTAINERS.md with the new streamlined process

## New release flow

```bash
# From main, clean working tree:
./scripts/release.sh rc       # next RC
./scripts/release.sh stable   # promote RC to stable
./scripts/release.sh 0.2.0    # explicit version
```

Then merge the PR. Everything else is automated:
1. `auto-release.yml` detects the `chore: bump version to X.Y.Z` commit message
2. Creates the git tag + GitHub Release (with auto-generated notes)
3. Existing `release.yml` and `publish.yml` trigger from the release event as before

## Test plan

- [ ] Review `scripts/release.sh` for correctness
- [ ] Review `auto-release.yml` workflow
- [ ] After merge, test with `./scripts/release.sh rc` to verify end-to-end flow