### PR TITLE
fix: handle pre-commit hook modifications in release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -157,7 +157,19 @@ git add \
     parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt \
     npm/package.json
 
-git commit -m "chore: bump version to $NEW_VERSION"
+# Commit — if pre-commit hooks modify files (e.g. uv.lock), re-stage and retry
+if ! git commit -m "chore: bump version to $NEW_VERSION"; then
+    echo "pre-commit hooks modified files, re-staging and retrying..."
+    git add \
+        pyproject.toml \
+        parallel_web_tools/__init__.py \
+        tests/test_cli.py \
+        parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt \
+        npm/package.json
+    # Also stage any lock files updated by hooks
+    git diff --name-only | xargs -r git add
+    git commit -m "chore: bump version to $NEW_VERSION"
+fi
 
 echo ""
 echo "pushing branch and creating PR..."


### PR DESCRIPTION
## Summary
- Release script now handles pre-commit hooks that modify files (e.g. `uv.lock` updated after version bump in `pyproject.toml`)
- If the initial commit fails due to hook modifications, the script re-stages all files and retries

## Context
Running `./scripts/release.sh rc` would fail silently at the commit step because pre-commit hooks modified `uv.lock`, leaving staged version bumps uncommitted on a new branch.

## Test plan
- [ ] Run `./scripts/release.sh rc` and verify it commits and creates PR successfully