### PR TITLE
fix: remove hardcoded version from test and release script

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,7 +21,7 @@ From the `main` branch with a clean working tree:
 
 This script will:
 1. Calculate the next version
-2. Update all 5 version files
+2. Update all 4 version files
 3. Create a `release/vX.Y.Z` branch
 4. Commit, push, and open a PR
 
@@ -36,7 +36,6 @@ After you merge the PR, everything else is automated:
 Update the version in these places:
 - `pyproject.toml`: `version = "X.Y.Z"`
 - `parallel_web_tools/__init__.py`: `__version__ = "X.Y.Z"`
-- `tests/test_cli.py`: version assertion in `test_version`
 - `parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt`: `parallel-web-tools>=X.Y.Z`
 - `npm/package.json`: `"version": "X.Y.Z"` (use semver pre-release format for RCs, e.g. `"X.Y.Z-rc.1"`)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -82,10 +82,7 @@ update_version_files() {
     # 2. parallel_web_tools/__init__.py
     sed -i '' "s/__version__ = \".*\"/__version__ = \"$new_version\"/" "$PROJECT_ROOT/parallel_web_tools/__init__.py"
 
-    # 3. tests/test_cli.py — update the version assertion
-    sed -i '' "s/assert \"[0-9][^\"]*\" in result.output/assert \"$new_version\" in result.output/" "$PROJECT_ROOT/tests/test_cli.py"
-
-    # 4. bigquery cloud function requirements.txt
+    # 3. bigquery cloud function requirements.txt
     sed -i '' "s/parallel-web-tools>=.*/parallel-web-tools>=$new_version/" \
         "$PROJECT_ROOT/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt"
 
@@ -153,7 +150,6 @@ git checkout -b "$BRANCH"
 git add \
     pyproject.toml \
     parallel_web_tools/__init__.py \
-    tests/test_cli.py \
     parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt \
     npm/package.json
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,7 +234,9 @@ class TestMainCLI:
         """Should show version."""
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.1.0rc1" in result.output
+        from parallel_web_tools import __version__
+
+        assert __version__ in result.output
 
 
 class TestAuthCommand:


### PR DESCRIPTION
## Summary
- `test_cli.py` now imports `__version__` dynamically instead of hardcoding the version string
- Removes `test_cli.py` from the release script's sed/staging steps since it no longer needs updating per release
- Fixes a bug where the release script's sed regex was too greedy, replacing unrelated test assertions (e.g. `"3 completed"`, `"1 failed"`) with the version string

## Test plan
- [ ] Run tests to verify `test_version` still passes
- [ ] Run `./scripts/release.sh rc` and confirm `test_cli.py` is not modified