### PR TITLE
fix: auto-release tag parsing with squash-merge PR numbers

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -21,7 +21,7 @@ jobs:
         id: check
         run: |
           COMMIT_MSG="${{ github.event.head_commit.message }}"
-          if [[ "$COMMIT_MSG" =~ ^chore:\ bump\ version\ to\ (.+)$ ]]; then
+          if [[ "$COMMIT_MSG" =~ ^chore:\ bump\ version\ to\ ([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Fix version regex in `auto-release.yml` to capture only the version string, not trailing text like ` (#48)` appended by GitHub squash merges
- Changes `(.+)$` to `([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?)` so the tag is `v0.1.0rc2` instead of `v0.1.0rc2 (#48)`

## Context
The auto-release workflow failed for v0.1.0rc2 because the extracted tag name included the PR number suffix, which is not a valid git tag.

## Test plan
- [ ] Merge this PR, then re-run the failed auto-release workflow for the v0.1.0rc2 commit