### PR TITLE
fix: trigger downstream workflows from auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   check:
@@ -65,3 +66,10 @@ jobs:
             --title "${{ needs.check.outputs.tag }}" \
             --generate-notes \
             $PRERELEASE_FLAG
+
+      - name: Trigger downstream workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml -f tag=${{ needs.check.outputs.tag }}
+          gh workflow run publish.yml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Releases created by `auto-release.yml` using `GITHUB_TOKEN` don't trigger `release: created/published` events (GitHub limitation to prevent infinite loops)
- Auto-release now explicitly dispatches `release.yml` (build binaries + npm) and `publish.yml` (PyPI) after creating the release
- Adds `workflow_dispatch` trigger to `publish.yml` so it can be dispatched
- Adds `actions: write` permission to auto-release workflow

## Context
v0.1.0rc3 release was created successfully but binary builds, PyPI publish, and npm publish never ran.

## Test plan
- [ ] Merge and run `./scripts/release.sh rc` to create v0.1.0rc4
- [ ] Verify all three downstream workflows trigger after auto-release