### PR TITLE
fix: npm publish fails when version already matches tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Update package.json version
         working-directory: npm
-        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version
+        run: npm version "${{ steps.version.outputs.version }}" --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         working-directory: npm


### PR DESCRIPTION
## Summary
- Add `--allow-same-version` to the `npm version` step in `release.yml`
- The release script already sets the correct version in `package.json`, so `npm version` fails with "Version not changed" when the tag matches

## Context
v0.1.0 npm publish failed because `package.json` already had `"version": "0.1.0"`.

## Test plan
- [ ] Merge and re-run the failed v0.1.0 release workflow