### PR TITLE
fix: pin Linux builds to Ubuntu 22.04 for broader glibc compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
             platform: darwin-arm64
           - os: macos-15-large
             platform: darwin-x64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             platform: linux-x64
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             platform: linux-arm64
           - os: windows-latest
             platform: windows-x64


### PR DESCRIPTION
## Summary
- Pin Linux x64 build from `ubuntu-latest` (24.04, glibc 2.39) to `ubuntu-22.04` (glibc 2.35)
- Pin Linux arm64 build from `ubuntu-24.04-arm` to `ubuntu-22.04-arm` (glibc 2.35)
- Fixes standalone CLI failing on systems with glibc < 2.38 (e.g. Debian 12 bookworm)

## Context
Users reported that `parallel-cli` fails to run on systems with older glibc versions. The PyInstaller binary was linked against glibc 2.38+ from the Ubuntu 24.04 build runner, but environments like Debian 12 only have glibc 2.36.

Building on Ubuntu 22.04 (glibc 2.35) ensures compatibility with Debian 12+, Ubuntu 22.04+, RHEL 9+, and Fedora 36+.

## Test plan
- [ ] Trigger a release build via `workflow_dispatch` and verify Linux binaries are produced
- [ ] Test the resulting binary on a Debian 12 (glibc 2.36) system
- [ ] Verify `parallel-cli login` works end-to-end on the older glibc system