### PR TITLE
chore: bump version to 0.1.2

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-web-cli",
-  "version": "0.1.2-rc.2",
+  "version": "0.1.2",
   "description": "CLI for the Parallel API — web search, data enrichment, and monitoring",
   "homepage": "https://github.com/parallel-web/parallel-web-tools",
   "repository": {

--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -29,7 +29,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.1.2rc2"
+__version__ = "0.1.2"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.1.2rc2
+parallel-web-tools>=0.1.2
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.1.2rc2"
+version = "0.1.2"
 description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1368,7 +1368,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.1.2rc2"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release 0.1.2

Bumps version from 0.1.2rc2 to 0.1.2.

When this PR is merged to main, the release workflow will automatically:
- Create tag `v0.1.2`
- Create a GitHub Release with auto-generated notes
- Build binaries for all platforms
- Publish to PyPI
- Publish to npm