### PR TITLE
feat: add shell completion support for bash, zsh, and fish

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -2863,5 +2863,129 @@ def monitor_simulate(monitor_id: str, event_type: str | None, output_json: bool)
         _handle_error(e, output_json=output_json)
 
 
+# =============================================================================
+# Shell Completion
+# =============================================================================
+
+SUPPORTED_SHELLS = ["bash", "zsh", "fish"]
+
+# Completion script templates using Click's built-in shell completion.
+# These eval the _PARALLEL_CLI_COMPLETE env var at shell startup.
+_COMPLETION_SCRIPTS = {
+    "bash": 'eval "$(_PARALLEL_CLI_COMPLETE=bash_source parallel-cli)"',
+    "zsh": 'eval "$(_PARALLEL_CLI_COMPLETE=zsh_source parallel-cli)"',
+    "fish": "_PARALLEL_CLI_COMPLETE=fish_source parallel-cli | source",
+}
+
+# Default shell config file paths
+_SHELL_CONFIG_FILES = {
+    "bash": "~/.bashrc",
+    "zsh": "~/.zshrc",
+    "fish": "~/.config/fish/config.fish",
+}
+
+# Guard comment to prevent duplicate installs
+_GUARD_COMMENT = "# parallel-cli shell completion"
+
+
+def _detect_shell() -> str | None:
+    """Detect the current shell from the SHELL environment variable."""
+    shell_path = os.environ.get("SHELL", "")
+    for shell in SUPPORTED_SHELLS:
+        if shell in shell_path:
+            return shell
+    return None
+
+
+@main.group()
+def completion():
+    """Shell completion for bash, zsh, and fish."""
+    pass
+
+
+@completion.command(name="show")
+@click.option(
+    "--shell",
+    "shell_name",
+    type=click.Choice(SUPPORTED_SHELLS),
+    default=None,
+    help="Shell type (auto-detected from $SHELL if not specified)",
+)
+def completion_show(shell_name: str | None):
+    """Print the shell completion script to stdout.
+
+    The output can be saved to a file or eval'd directly:
+
+    \b
+        # Add to your shell config
+        parallel-cli completion show --shell zsh >> ~/.zshrc
+
+        # Or eval directly
+        eval "$(parallel-cli completion show --shell bash)"
+    """
+    if shell_name is None:
+        shell_name = _detect_shell()
+        if shell_name is None:
+            console.print("[red]Could not detect shell.[/red] Use --shell to specify: bash, zsh, or fish")
+            sys.exit(EXIT_BAD_INPUT)
+
+    click.echo(_COMPLETION_SCRIPTS[shell_name])
+
+
+@completion.command(name="install")
+@click.option(
+    "--shell",
+    "shell_name",
+    type=click.Choice(SUPPORTED_SHELLS),
+    default=None,
+    help="Shell type (auto-detected from $SHELL if not specified)",
+)
+def completion_install(shell_name: str | None):
+    """Install shell completions for the current shell.
+
+    Appends the completion script to your shell config file.
+    Safe to run multiple times (won't add duplicates).
+
+    \b
+    Examples:
+        parallel-cli completion install
+        parallel-cli completion install --shell zsh
+    """
+    if _STANDALONE_MODE:
+        console.print(
+            "[yellow]Shell completions are not supported in standalone binary mode.[/yellow]\n"
+            "Install via pip to use completions: "
+            "[cyan]pip install parallel-web-tools[/cyan]"
+        )
+        sys.exit(EXIT_BAD_INPUT)
+
+    if shell_name is None:
+        shell_name = _detect_shell()
+        if shell_name is None:
+            console.print("[red]Could not detect shell.[/red] Use --shell to specify: bash, zsh, or fish")
+            sys.exit(EXIT_BAD_INPUT)
+
+    config_path = os.path.expanduser(_SHELL_CONFIG_FILES[shell_name])
+    script_line = _COMPLETION_SCRIPTS[shell_name]
+    install_line = f"{_GUARD_COMMENT}\n{script_line}\n"
+
+    # Check for existing installation
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            content = f.read()
+        if _GUARD_COMMENT in content:
+            console.print(f"[green]Shell completions already installed[/green] in {config_path}")
+            return
+
+    # Append to config file
+    os.makedirs(os.path.dirname(config_path), exist_ok=True)
+    with open(config_path, "a") as f:
+        f.write(f"\n{install_line}")
+
+    console.print("[bold green]Shell completions installed![/bold green]")
+    console.print(f"[dim]Added to {config_path}[/dim]")
+    console.print(f"\nRestart your shell or run: [cyan]source {config_path}[/cyan]")
+
+
 if __name__ == "__main__":
     main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1737,3 +1737,74 @@ class TestEnrichRunJsonOutput:
         assert isinstance(data, list)
         assert len(data) == 1
         assert data[0]["company"] == "Google"
+
+
+class TestCompletion:
+    """Tests for the shell completion commands."""
+
+    def test_completion_show_bash(self, runner):
+        """Should output bash completion script."""
+        result = runner.invoke(main, ["completion", "show", "--shell", "bash"])
+        assert result.exit_code == 0
+        assert "_PARALLEL_CLI_COMPLETE=bash_source" in result.output
+
+    def test_completion_show_zsh(self, runner):
+        """Should output zsh completion script."""
+        result = runner.invoke(main, ["completion", "show", "--shell", "zsh"])
+        assert result.exit_code == 0
+        assert "_PARALLEL_CLI_COMPLETE=zsh_source" in result.output
+
+    def test_completion_show_fish(self, runner):
+        """Should output fish completion script."""
+        result = runner.invoke(main, ["completion", "show", "--shell", "fish"])
+        assert result.exit_code == 0
+        assert "_PARALLEL_CLI_COMPLETE=fish_source" in result.output
+
+    def test_completion_show_auto_detect(self, runner):
+        """Should auto-detect shell from SHELL env var."""
+        with mock.patch.dict(os.environ, {"SHELL": "/bin/zsh"}):
+            result = runner.invoke(main, ["completion", "show"])
+        assert result.exit_code == 0
+        assert "_PARALLEL_CLI_COMPLETE=zsh_source" in result.output
+
+    def test_completion_show_unknown_shell(self, runner):
+        """Should fail gracefully when shell cannot be detected."""
+        with mock.patch.dict(os.environ, {"SHELL": "/bin/unknown"}, clear=False):
+            result = runner.invoke(main, ["completion", "show"])
+        assert result.exit_code != 0
+
+    def test_completion_install_creates_config(self, runner, tmp_path):
+        """Should append completion line to shell config."""
+        config_file = tmp_path / ".zshrc"
+        config_file.write_text("# existing config\n")
+
+        with mock.patch(
+            "parallel_web_tools.cli.commands._SHELL_CONFIG_FILES",
+            {"bash": str(tmp_path / ".bashrc"), "zsh": str(config_file), "fish": str(tmp_path / "config.fish")},
+        ):
+            result = runner.invoke(main, ["completion", "install", "--shell", "zsh"])
+
+        assert result.exit_code == 0
+        content = config_file.read_text()
+        assert "# parallel-cli shell completion" in content
+        assert "_PARALLEL_CLI_COMPLETE=zsh_source" in content
+
+    def test_completion_install_idempotent(self, runner, tmp_path):
+        """Should not add duplicate completion lines."""
+        config_file = tmp_path / ".zshrc"
+        config_file.write_text("# parallel-cli shell completion\neval ...\n")
+
+        with mock.patch(
+            "parallel_web_tools.cli.commands._SHELL_CONFIG_FILES",
+            {"bash": str(tmp_path / ".bashrc"), "zsh": str(config_file), "fish": str(tmp_path / "config.fish")},
+        ):
+            result = runner.invoke(main, ["completion", "install", "--shell", "zsh"])
+
+        assert result.exit_code == 0
+        assert "already installed" in result.output
+
+    def test_completion_install_standalone_rejected(self, runner):
+        """Should reject install in standalone binary mode."""
+        with mock.patch("parallel_web_tools.cli.commands._STANDALONE_MODE", True):
+            result = runner.invoke(main, ["completion", "install", "--shell", "bash"])
+        assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Adds a `parallel-cli completion` command group for shell tab-completion:

- `parallel-cli completion show [--shell bash|zsh|fish]` - Print the completion script to stdout
- `parallel-cli completion install [--shell bash|zsh|fish]` - Auto-install to your shell config file

Uses Click's built-in shell completion system, so completions stay in sync as commands are added. Shell is auto-detected from `$SHELL` with `--shell` override.

### Usage

```bash
# Auto-install for your current shell
parallel-cli completion install

# Or manually add to your config
parallel-cli completion show --shell zsh >> ~/.zshrc
```

### Details

- Supports bash, zsh, and fish
- Install is idempotent (guard comment prevents duplicates)
- Standalone binary mode (PyInstaller) is detected and rejected gracefully with a helpful message - completions require the pip-installed version
- 8 new tests covering all shells, auto-detection, idempotency, and standalone rejection

<details>
<summary>Research & Context</summary>

### Project Context
- The CLI has a deep command tree (search, extract, research, enrich, findall, monitor) with many subcommands and options
- Shell completions are table-stakes UX for CLI tools - every mature CLI ships them
- Click 8.1+ has built-in completion support that just needs to be exposed

### Competitive Analysis
- Most Python CLI tools using Click ship completion support
- Typer (which wraps Click) auto-generates completion install commands
- This brings parallel-cli in line with CLI UX expectations

</details>

This contribution was developed with AI assistance (Claude Code).