### PR TITLE
feat: add wordmark banner and update CLI copy

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -78,6 +78,44 @@ logging.getLogger("httpx").setLevel(logging.WARNING)
 logging.getLogger("httpcore").setLevel(logging.WARNING)
 console = Console()
 
+# Parallel wordmark — rendered from white-parallel-text-1080.png
+# using half-block characters (▀▄█) for terminal display
+_BANNER_LINES = [
+    "[bold white]                                                        █████ █████                █████[/]",
+    "[bold white]                                                        █████ █████                █████[/]",
+    "[bold white]████████████▄  ▄███████████  ███████████▄ ████████████  █████ █████ ▄████████████▄ █████[/]",
+    "[bold white]█████   █████  ▀▀▀▀▀   █████ █████  ▀▀▀▀▀ ▀▀▀▀   █████▄ █████ █████ █████    █████ █████[/]",
+    "[bold white]█████   █████  ▄████████████ █████       ▄█████████████ █████ █████ ██████████████ █████[/]",
+    "[bold white]█████   █████ █████    █████ █████       █████   ▀█████ █████ █████ █████    █████ █████[/]",
+    "[bold white]████████████▀ ▀█████████████ █████       ▀█████████████ █████ █████ ▀████████████▀ █████[/]",
+    "[bold white]█████[/]",
+    "[bold white]█████[/]",
+]
+
+
+def _print_banner():
+    """Print the Parallel CLI banner with logo."""
+    if not console.is_terminal:
+        return
+    banner = "\n".join(line.format(version=__version__) for line in _BANNER_LINES)
+    console.print(banner, highlight=False)
+    console.print()
+    console.print(
+        f"  [bold #fb631b]parallel-cli[/bold #fb631b] v{__version__}  [dim]AI-powered web intelligence for your agent[/dim]",
+        highlight=False,
+    )
+    console.print("  [dim]Get started at[/dim] [dim link=https://parallel.ai]parallel.ai[/dim link]", highlight=False)
+    console.print()
+
+
+class ParallelCLI(click.Group):
+    """Custom Click group that shows the Parallel banner on help."""
+
+    def format_help(self, ctx, formatter):
+        _print_banner()
+        super().format_help(ctx, formatter)
+
+
 load_dotenv(".env.local")
 
 # Source types available for enrich run/plan
@@ -388,10 +426,10 @@ def _auto_update():
         pass
 
 
-@click.group()
+@click.group(cls=ParallelCLI)
 @click.version_option(version=__version__, prog_name="parallel-cli")
 def main():
-    """Parallel CLI - AI-powered data enrichment and search."""
+    """Parallel CLI - Search, research, enrich, and monitor the web."""
     pass
 
 
@@ -424,8 +462,9 @@ def auth(output_json: bool):
             console.print(f"  Credentials: {status['token_file']}")
     else:
         console.print("[yellow]Not authenticated[/yellow]")
-        console.print("\n[cyan]To authenticate:[/cyan]")
-        console.print("  Run: parallel-cli login")
+        console.print("\n[cyan]To get started:[/cyan]")
+        console.print("  1. Create an account at [link=https://parallel.ai]parallel.ai[/link]")
+        console.print("  2. Run: parallel-cli login")
         console.print("  Or set PARALLEL_API_KEY environment variable")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "parallel-web-tools"
 version = "0.1.2"
-description = "Parallel Tools: CLI and data enrichment utilities for the Parallel API"
+description = "Parallel Tools: CLI and Python SDK for AI-powered web intelligence"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add "parallel" wordmark banner rendered from the official brand asset (`white-parallel-text-1080.png`) using half-block unicode characters, displayed on `--help` via a custom `ParallelCLI` click group
- Update CLI tagline to "Search, research, enrich, and monitor the web"
- Update pyproject.toml description to "AI-powered web intelligence"
- Add account creation guidance ("Create an account at parallel.ai") to the `auth` command output

## Test plan
- [x] All 587 tests pass
- [ ] Run `parallel-cli` or `parallel-cli --help` in a terminal and verify the wordmark renders correctly in bold white
- [ ] Verify "parallel-cli" label below the wordmark renders in orange (#fb631b)
- [ ] Verify banner is suppressed when output is piped (e.g., `parallel-cli --help | cat`)
- [ ] Run `parallel-cli auth` without credentials and verify account creation guidance appears