### PR TITLE
fix: serialize search Warning objects as dicts in JSON output

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -753,7 +753,11 @@ def search(
                 {"url": r.url, "title": r.title, "publish_date": r.publish_date, "excerpts": r.excerpts}
                 for r in result.results
             ],
-            "warnings": result.warnings if hasattr(result, "warnings") else [],
+            "warnings": [
+                {"type": w.type, "message": w.message, "detail": getattr(w, "detail", None)} for w in result.warnings
+            ]
+            if hasattr(result, "warnings") and result.warnings
+            else [],
         }
 
         write_json_output(output_data, output_file, output_json)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1006,6 +1006,45 @@ class TestSearchCommandMocked:
         assert len(output["results"]) == 1
         assert output["results"][0]["url"] == "https://example.com"
 
+    def test_search_warnings_serialized_in_json_output(self, runner):
+        """Should serialize SDK Warning objects as dicts in JSON output."""
+        mock_search_result = mock.MagicMock()
+        mock_search_result.search_id = "search_456"
+        mock_search_result.results = [
+            mock.MagicMock(
+                url="https://example.com",
+                title="Example",
+                publish_date="2024-01-01",
+                excerpts=["An excerpt"],
+            )
+        ]
+        # Simulate SDK returning Warning objects matching the API schema
+        warning_obj = mock.MagicMock()
+        warning_obj.type = "warning"
+        warning_obj.message = "Excerpts truncated to 500 characters"
+        warning_obj.detail = {"max_chars_total": 500}
+        mock_search_result.warnings = [warning_obj]
+
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                mock_client.beta.search.return_value = mock_search_result
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(main, ["search", "test query", "--json"])
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        output = json.loads(result.output)
+        assert len(output["warnings"]) == 1
+        warning = output["warnings"][0]
+        assert warning["type"] == "warning"
+        assert warning["message"] == "Excerpts truncated to 500 characters"
+        assert warning["detail"] == {"max_chars_total": 500}
+
     def test_search_api_error_json_mode(self, runner):
         """Should output JSON error when API fails in --json mode."""
         with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):


### PR DESCRIPTION
## Summary
- `--excerpt-max-chars-total` crashes JSON output (exit code 4) when excerpts are truncated, because the SDK returns `Warning` objects that aren't JSON-serializable
- Convert `Warning` objects to dicts preserving the full API schema (`type`, `message`, `detail`) instead of passing them straight to `json.dumps`
- Add test that mocks SDK `Warning` objects and asserts structured dict output — fails without the fix (exit 4), passes with it

## Test plan
- [x] New test `test_search_warnings_serialized_in_json_output` verifies Warning objects serialize as dicts
- [x] Verified test fails without fix (exit code 4) and passes with fix
- [x] Full test suite passes (135 tests)