### PR TITLE
fix: skip auto-release workflow on non-version pushes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,8 @@ name: Auto Release
 on:
   push:
     branches: [main]
+    paths:
+      - 'pyproject.toml'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `paths` filter to `auto-release.yml` so it only triggers when `pyproject.toml` changes
- Prevents unnecessary failed workflow runs on regular (non-release) pushes to main
- Version bump commits always modify `pyproject.toml`, so release detection is unaffected

## Test plan
- [ ] Push a non-version-bump commit to main and verify the auto-release workflow does not trigger
- [ ] Run `./scripts/release.sh rc` and verify the auto-release workflow triggers correctly on merge