### PR TITLE
feat: enable shell completions for standalone binary

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -3004,14 +3004,6 @@ def completion_install(shell_name: str | None):
         parallel-cli completion install
         parallel-cli completion install --shell zsh
     """
-    if _STANDALONE_MODE:
-        console.print(
-            "[yellow]Shell completions are not supported in standalone binary mode.[/yellow]\n"
-            "Install via pip to use completions: "
-            "[cyan]pip install parallel-web-tools[/cyan]"
-        )
-        sys.exit(EXIT_BAD_INPUT)
-
     if shell_name is None:
         shell_name = _detect_shell()
         if shell_name is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1918,8 +1918,18 @@ class TestCompletion:
         assert result.exit_code == 0
         assert "already installed" in result.output
 
-    def test_completion_install_standalone_rejected(self, runner):
-        """Should reject install in standalone binary mode."""
-        with mock.patch("parallel_web_tools.cli.commands._STANDALONE_MODE", True):
+    def test_completion_install_works_in_standalone(self, runner, tmp_path):
+        """Should install completions even in standalone binary mode."""
+        config_file = tmp_path / ".bashrc"
+        config_file.write_text("")
+        with (
+            mock.patch("parallel_web_tools.cli.commands._STANDALONE_MODE", True),
+            mock.patch(
+                "parallel_web_tools.cli.commands._SHELL_CONFIG_FILES",
+                {"bash": str(config_file), "zsh": str(tmp_path / ".zshrc"), "fish": str(tmp_path / "config.fish")},
+            ),
+        ):
             result = runner.invoke(main, ["completion", "install", "--shell", "bash"])
-        assert result.exit_code != 0
+        assert result.exit_code == 0
+        content = config_file.read_text()
+        assert "# parallel-cli shell completion" in content


### PR DESCRIPTION
## Summary
- Removes the `_STANDALONE_MODE` guard from `completion install`, allowing shell completions to work in PyInstaller standalone binaries
- Click's `_PARALLEL_CLI_COMPLETE` env var is intercepted at the framework level before any command logic runs, so it works correctly regardless of install method
- Updates tests to verify completions install successfully in standalone mode

## Test plan
- [ ] Verify `parallel-cli completion install` works from a pip install
- [ ] Verify `parallel-cli completion install` works from a standalone binary
- [ ] Run `uv run pytest tests/test_cli.py -k completion` to confirm test updates pass