### PR TITLE
feat(cli): migrate search and extract to parallel-web V1 API

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -651,15 +651,80 @@ def config_cmd(key: str | None, value: str | None, output_json: bool):
 # Search Command
 # =============================================================================
 
+# Beta -> V1 mode mapping. Beta had three modes; V1 has two. We keep the old
+# values as accepted CLI inputs and translate them so existing scripts work.
+_SEARCH_MODE_MAP = {
+    "fast": "basic",
+    "one-shot": "basic",
+    "agentic": "advanced",
+    "basic": "basic",
+    "advanced": "advanced",
+}
+_DEPRECATED_SEARCH_MODES = {"fast", "one-shot", "agentic"}
+
+
+def _emit_deprecation(message: str) -> None:
+    """Print a deprecation notice to stderr so it doesn't pollute --json output."""
+    click.echo(f"[deprecated] {message}", err=True)
+
+
+def build_search_v1_kwargs(
+    *,
+    objective: str | None,
+    query: tuple[str, ...] | list[str],
+    mode: str | None,
+    max_results: int | None,
+    source_policy: dict[str, Any] | None,
+    excerpt_max_chars_per_result: int | None,
+    excerpt_max_chars_total: int | None,
+    fetch_policy: dict[str, Any] | None,
+    location: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Translate Beta-style search params to V1 client.search() kwargs.
+
+    V1 requires search_queries; if the caller only provided an objective, we
+    fall back to using it as the single query so older invocations keep working.
+    """
+    queries = list(query) if query else []
+    if not queries and objective:
+        queries = [objective]
+
+    kwargs: dict[str, Any] = {"search_queries": queries}
+    if objective:
+        kwargs["objective"] = objective
+    if mode:
+        kwargs["mode"] = _SEARCH_MODE_MAP.get(mode, mode)
+    if excerpt_max_chars_total is not None:
+        kwargs["max_chars_total"] = excerpt_max_chars_total
+    if session_id:
+        kwargs["session_id"] = session_id
+
+    advanced: dict[str, Any] = {}
+    if max_results is not None:
+        advanced["max_results"] = max_results
+    if source_policy:
+        advanced["source_policy"] = source_policy
+    if fetch_policy:
+        advanced["fetch_policy"] = fetch_policy
+    if excerpt_max_chars_per_result is not None:
+        advanced["excerpt_settings"] = {"max_chars_per_result": excerpt_max_chars_per_result}
+    if location:
+        advanced["location"] = location
+    if advanced:
+        kwargs["advanced_settings"] = advanced
+
+    return kwargs
+
 
 @main.command()
 @click.argument("objective", required=False)
 @click.option("-q", "--query", multiple=True, help="Keyword search query (can be repeated)")
 @click.option(
     "--mode",
-    type=click.Choice(["one-shot", "agentic", "fast"]),
-    default="fast",
-    help="Search mode",
+    type=click.Choice(list(_SEARCH_MODE_MAP.keys())),
+    default="basic",
+    help="Search mode (one-shot/fast → basic, agentic → advanced)",
     show_default=True,
 )
 @click.option("--max-results", type=int, default=10, help="Maximum results", show_default=True)
@@ -673,6 +738,8 @@ def config_cmd(key: str | None, value: str | None, output_json: bool):
 @click.option("--max-age-seconds", type=int, help="Max age in seconds before fetching live content (min 600)")
 @click.option("--timeout-seconds", type=float, help="Timeout in seconds for fetching live content")
 @click.option("--disable-cache-fallback", is_flag=True, help="Return error instead of stale cached content")
+@click.option("--location", help="ISO 3166-1 alpha-2 country code for geo-targeted results (e.g. us, gb, de)")
+@click.option("--session-id", help="Session ID to group related search/extract calls")
 @click.option("-o", "--output", "output_file", type=click.Path(), help="Save results to file (JSON)")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def search(
@@ -688,6 +755,8 @@ def search(
     max_age_seconds: int | None,
     timeout_seconds: float | None,
     disable_cache_fallback: bool,
+    location: str | None,
+    session_id: str | None,
     output_file: str | None,
     output_json: bool,
 ):
@@ -704,6 +773,13 @@ def search(
     if not objective and not query:
         raise click.UsageError("Provide an OBJECTIVE argument or at least one --query option.")
 
+    if mode in _DEPRECATED_SEARCH_MODES:
+        new_mode = _SEARCH_MODE_MAP[mode]
+        _emit_deprecation(
+            f"--mode {mode} is a Beta value and will stop working after the Beta API sunset (June 2026). "
+            f"Use --mode {new_mode} instead."
+        )
+
     try:
         from parallel import Parallel
 
@@ -712,12 +788,6 @@ def search(
         api_key = get_api_key()
         client = Parallel(api_key=api_key, default_headers=get_default_headers("cli"))
 
-        search_kwargs: dict[str, Any] = {"mode": mode, "max_results": max_results}
-        if objective:
-            search_kwargs["objective"] = objective
-        if query:
-            search_kwargs["search_queries"] = list(query)
-
         source_policy: dict[str, Any] = {}
         if include_domains:
             source_policy["include_domains"] = parse_comma_separated(include_domains)
@@ -725,16 +795,7 @@ def search(
             source_policy["exclude_domains"] = parse_comma_separated(exclude_domains)
         if after_date:
             source_policy["after_date"] = after_date
-        if source_policy:
-            search_kwargs["source_policy"] = source_policy
 
-        # Excerpt settings (max_chars_total has a default, so always set)
-        excerpts_settings: dict[str, Any] = {"max_chars_total": excerpt_max_chars_total}
-        if excerpt_max_chars_per_result is not None:
-            excerpts_settings["max_chars_per_result"] = excerpt_max_chars_per_result
-        search_kwargs["excerpts"] = excerpts_settings
-
-        # Fetch policy
         fetch_policy: dict[str, Any] = {}
         if max_age_seconds is not None:
             fetch_policy["max_age_seconds"] = max_age_seconds
@@ -742,13 +803,24 @@ def search(
             fetch_policy["timeout_seconds"] = timeout_seconds
         if disable_cache_fallback:
             fetch_policy["disable_cache_fallback"] = True
-        if fetch_policy:
-            search_kwargs["fetch_policy"] = fetch_policy
+
+        search_kwargs = build_search_v1_kwargs(
+            objective=objective,
+            query=query,
+            mode=mode,
+            max_results=max_results,
+            source_policy=source_policy or None,
+            excerpt_max_chars_per_result=excerpt_max_chars_per_result,
+            excerpt_max_chars_total=excerpt_max_chars_total,
+            fetch_policy=fetch_policy or None,
+            location=location,
+            session_id=session_id,
+        )
 
         if not output_json:
             console.print("[dim]Searching...[/dim]\n")
 
-        result = client.beta.search(**search_kwargs)
+        result = client.search(**search_kwargs)
 
         output_data = {
             "search_id": result.search_id,
@@ -787,18 +859,62 @@ def search(
 # =============================================================================
 
 
+def build_extract_v1_kwargs(
+    *,
+    urls: tuple[str, ...] | list[str],
+    objective: str | None,
+    query: tuple[str, ...] | list[str],
+    full_content: bool,
+    full_content_max_chars: int | None,
+    excerpt_max_chars_per_result: int | None,
+    excerpt_max_chars_total: int | None,
+    fetch_policy: dict[str, Any] | None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Translate Beta-style extract params to V1 client.extract() kwargs.
+
+    Note: V1 always returns excerpts; the old `--no-excerpts` flag can no longer
+    disable them server-side. The CLI handles that flag by filtering excerpts out
+    of the output, not by passing it to the SDK.
+    """
+    kwargs: dict[str, Any] = {"urls": list(urls)}
+    if objective:
+        kwargs["objective"] = objective
+    if query:
+        kwargs["search_queries"] = list(query)
+    if excerpt_max_chars_total is not None:
+        kwargs["max_chars_total"] = excerpt_max_chars_total
+    if session_id:
+        kwargs["session_id"] = session_id
+
+    advanced: dict[str, Any] = {}
+    if excerpt_max_chars_per_result is not None:
+        advanced["excerpt_settings"] = {"max_chars_per_result": excerpt_max_chars_per_result}
+    if full_content_max_chars is not None:
+        advanced["full_content"] = {"max_chars_per_result": full_content_max_chars}
+    elif full_content:
+        advanced["full_content"] = True
+    if fetch_policy:
+        advanced["fetch_policy"] = fetch_policy
+    if advanced:
+        kwargs["advanced_settings"] = advanced
+
+    return kwargs
+
+
 @main.command()
 @click.argument("urls", nargs=-1, required=True)
 @click.option("--objective", help="Focus extraction on a specific goal")
 @click.option("-q", "--query", multiple=True, help="Keywords to prioritize (can be repeated)")
 @click.option("--full-content", is_flag=True, help="Include complete page content")
 @click.option("--full-content-max-chars", type=int, help="Max characters per result for full content")
-@click.option("--no-excerpts", is_flag=True, help="Exclude excerpts from output")
+@click.option("--no-excerpts", is_flag=True, help="Strip excerpts from output (V1 always returns them server-side)")
 @click.option("--excerpt-max-chars-per-result", type=int, help="Max characters per result for excerpts (min 1000)")
 @click.option("--excerpt-max-chars-total", type=int, help="Max total characters for excerpts across all URLs")
 @click.option("--max-age-seconds", type=int, help="Max age in seconds before fetching live content (min 600)")
 @click.option("--timeout-seconds", type=float, help="Timeout in seconds for fetching live content")
 @click.option("--disable-cache-fallback", is_flag=True, help="Return error instead of stale cached content")
+@click.option("--session-id", help="Session ID to group related search/extract calls")
 @click.option("-o", "--output", "output_file", type=click.Path(), help="Save results to file (JSON)")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def extract(
@@ -813,10 +929,17 @@ def extract(
     max_age_seconds: int | None,
     timeout_seconds: float | None,
     disable_cache_fallback: bool,
+    session_id: str | None,
     output_file: str | None,
     output_json: bool,
 ):
     """Extract content from URLs as clean markdown."""
+    if no_excerpts:
+        _emit_deprecation(
+            "--no-excerpts no longer disables excerpts server-side (V1 always returns them); "
+            "the flag now just strips them from the CLI output."
+        )
+
     try:
         from parallel import Parallel
 
@@ -825,30 +948,6 @@ def extract(
         api_key = get_api_key()
         client = Parallel(api_key=api_key, default_headers=get_default_headers("cli"))
 
-        extract_kwargs: dict[str, Any] = {
-            "urls": list(urls),
-        }
-
-        # Excerpt settings - can be bool or object with settings
-        if no_excerpts:
-            extract_kwargs["excerpts"] = False
-        elif excerpt_max_chars_per_result is not None or excerpt_max_chars_total is not None:
-            excerpts_settings: dict[str, Any] = {}
-            if excerpt_max_chars_per_result is not None:
-                excerpts_settings["max_chars_per_result"] = excerpt_max_chars_per_result
-            if excerpt_max_chars_total is not None:
-                excerpts_settings["max_chars_total"] = excerpt_max_chars_total
-            extract_kwargs["excerpts"] = excerpts_settings
-        else:
-            extract_kwargs["excerpts"] = True
-
-        # Full content settings - can be bool or object with settings
-        if full_content_max_chars is not None:
-            extract_kwargs["full_content"] = {"max_chars_per_result": full_content_max_chars}
-        else:
-            extract_kwargs["full_content"] = full_content
-
-        # Fetch policy
         fetch_policy: dict[str, Any] = {}
         if max_age_seconds is not None:
             fetch_policy["max_age_seconds"] = max_age_seconds
@@ -856,23 +955,28 @@ def extract(
             fetch_policy["timeout_seconds"] = timeout_seconds
         if disable_cache_fallback:
             fetch_policy["disable_cache_fallback"] = True
-        if fetch_policy:
-            extract_kwargs["fetch_policy"] = fetch_policy
 
-        if objective:
-            extract_kwargs["objective"] = objective
-        if query:
-            extract_kwargs["search_queries"] = list(query)
+        extract_kwargs = build_extract_v1_kwargs(
+            urls=urls,
+            objective=objective,
+            query=query,
+            full_content=full_content,
+            full_content_max_chars=full_content_max_chars,
+            excerpt_max_chars_per_result=excerpt_max_chars_per_result,
+            excerpt_max_chars_total=excerpt_max_chars_total,
+            fetch_policy=fetch_policy or None,
+            session_id=session_id,
+        )
 
         if not output_json:
             console.print(f"[dim]Extracting content from {len(urls)} URL(s)...[/dim]\n")
 
-        result = client.beta.extract(**extract_kwargs)
+        result = client.extract(**extract_kwargs)
 
         results_list = []
         for r in result.results:
             result_dict: dict[str, Any] = {"url": r.url, "title": r.title, "publish_date": r.publish_date}
-            if hasattr(r, "excerpts") and r.excerpts:
+            if not no_excerpts and hasattr(r, "excerpts") and r.excerpts:
                 result_dict["excerpts"] = r.excerpts
             if hasattr(r, "full_content") and r.full_content:
                 result_dict["full_content"] = r.full_content
@@ -914,7 +1018,7 @@ def extract(
                 console.print(f"[bold cyan]{r.title}[/bold cyan]")
                 console.print(f"[link={r.url}]{r.url}[/link]\n")
 
-                if hasattr(r, "excerpts") and r.excerpts:
+                if not no_excerpts and hasattr(r, "excerpts") and r.excerpts:
                     console.print("[dim]Excerpts:[/dim]")
                     for excerpt in r.excerpts[:3]:
                         text = excerpt[:300] + "..." if len(excerpt) > 300 else excerpt

--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -680,6 +680,7 @@ def build_search_v1_kwargs(
     fetch_policy: dict[str, Any] | None,
     location: str | None = None,
     session_id: str | None = None,
+    client_model: str | None = None,
 ) -> dict[str, Any]:
     """Translate Beta-style search params to V1 client.search() kwargs.
 
@@ -699,6 +700,8 @@ def build_search_v1_kwargs(
         kwargs["max_chars_total"] = excerpt_max_chars_total
     if session_id:
         kwargs["session_id"] = session_id
+    if client_model:
+        kwargs["client_model"] = client_model
 
     advanced: dict[str, Any] = {}
     if max_results is not None:
@@ -727,11 +730,11 @@ def build_search_v1_kwargs(
     help="Search mode (one-shot/fast → basic, agentic → advanced)",
     show_default=True,
 )
-@click.option("--max-results", type=int, default=10, help="Maximum results", show_default=True)
+@click.option("--max-results", type=int, help="Maximum results (defaults to server-side default of 10)")
 @click.option("--include-domains", multiple=True, help="Only search these domains (comma-separated or repeated)")
 @click.option("--exclude-domains", multiple=True, help="Exclude these domains (comma-separated or repeated)")
 @click.option("--after-date", help="Only results after this date (YYYY-MM-DD)")
-@click.option("--excerpt-max-chars-per-result", type=int, help="Max characters per result for excerpts")
+@click.option("--excerpt-max-chars-per-result", type=int, help="Max characters per result for excerpts (min 1000)")
 @click.option(
     "--excerpt-max-chars-total", type=int, default=60000, help="Max total characters for excerpts", show_default=True
 )
@@ -740,13 +743,17 @@ def build_search_v1_kwargs(
 @click.option("--disable-cache-fallback", is_flag=True, help="Return error instead of stale cached content")
 @click.option("--location", help="ISO 3166-1 alpha-2 country code for geo-targeted results (e.g. us, gb, de)")
 @click.option("--session-id", help="Session ID to group related search/extract calls")
+@click.option(
+    "--client-model",
+    help="The model generating this request and consuming the results (e.g. claude-opus-4-7, gpt-5.4, gemini-3.1-pro)",
+)
 @click.option("-o", "--output", "output_file", type=click.Path(), help="Save results to file (JSON)")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def search(
     objective: str | None,
     query: tuple[str, ...],
     mode: str,
-    max_results: int,
+    max_results: int | None,
     include_domains: tuple[str, ...],
     exclude_domains: tuple[str, ...],
     after_date: str | None,
@@ -757,6 +764,7 @@ def search(
     disable_cache_fallback: bool,
     location: str | None,
     session_id: str | None,
+    client_model: str | None,
     output_file: str | None,
     output_json: bool,
 ):
@@ -793,6 +801,11 @@ def search(
             source_policy["include_domains"] = parse_comma_separated(include_domains)
         if exclude_domains:
             source_policy["exclude_domains"] = parse_comma_separated(exclude_domains)
+        domain_total = len(source_policy.get("include_domains", [])) + len(source_policy.get("exclude_domains", []))
+        if domain_total > 200:
+            raise click.UsageError(
+                f"--include-domains and --exclude-domains combined must be <= 200 (got {domain_total})."
+            )
         if after_date:
             source_policy["after_date"] = after_date
 
@@ -815,6 +828,7 @@ def search(
             fetch_policy=fetch_policy or None,
             location=location,
             session_id=session_id,
+            client_model=client_model,
         )
 
         if not output_json:
@@ -824,11 +838,13 @@ def search(
 
         output_data = {
             "search_id": result.search_id,
+            "session_id": getattr(result, "session_id", None),
             "status": "ok",
             "results": [
                 {"url": r.url, "title": r.title, "publish_date": r.publish_date, "excerpts": r.excerpts}
                 for r in result.results
             ],
+            "usage": [{"name": u.name, "count": u.count} for u in (getattr(result, "usage", None) or [])],
             "warnings": [
                 {"type": w.type, "message": w.message, "detail": getattr(w, "detail", None)} for w in result.warnings
             ]
@@ -870,6 +886,7 @@ def build_extract_v1_kwargs(
     excerpt_max_chars_total: int | None,
     fetch_policy: dict[str, Any] | None,
     session_id: str | None = None,
+    client_model: str | None = None,
 ) -> dict[str, Any]:
     """Translate Beta-style extract params to V1 client.extract() kwargs.
 
@@ -886,6 +903,8 @@ def build_extract_v1_kwargs(
         kwargs["max_chars_total"] = excerpt_max_chars_total
     if session_id:
         kwargs["session_id"] = session_id
+    if client_model:
+        kwargs["client_model"] = client_model
 
     advanced: dict[str, Any] = {}
     if excerpt_max_chars_per_result is not None:
@@ -915,6 +934,10 @@ def build_extract_v1_kwargs(
 @click.option("--timeout-seconds", type=float, help="Timeout in seconds for fetching live content")
 @click.option("--disable-cache-fallback", is_flag=True, help="Return error instead of stale cached content")
 @click.option("--session-id", help="Session ID to group related search/extract calls")
+@click.option(
+    "--client-model",
+    help="The model generating this request and consuming the results (e.g. claude-opus-4-7, gpt-5.4, gemini-3.1-pro)",
+)
 @click.option("-o", "--output", "output_file", type=click.Path(), help="Save results to file (JSON)")
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 def extract(
@@ -930,6 +953,7 @@ def extract(
     timeout_seconds: float | None,
     disable_cache_fallback: bool,
     session_id: str | None,
+    client_model: str | None,
     output_file: str | None,
     output_json: bool,
 ):
@@ -939,6 +963,11 @@ def extract(
             "--no-excerpts no longer disables excerpts server-side (V1 always returns them); "
             "the flag now just strips them from the CLI output."
         )
+
+    if len(urls) > 20:
+        raise click.UsageError(f"V1 extract accepts at most 20 URLs per request (got {len(urls)}).")
+    if objective is not None and len(objective) > 5000:
+        raise click.UsageError(f"--objective must be 5000 characters or fewer (got {len(objective)}).")
 
     try:
         from parallel import Parallel
@@ -966,6 +995,7 @@ def extract(
             excerpt_max_chars_total=excerpt_max_chars_total,
             fetch_policy=fetch_policy or None,
             session_id=session_id,
+            client_model=client_model,
         )
 
         if not output_json:
@@ -996,9 +1026,11 @@ def extract(
 
         output_data = {
             "extract_id": result.extract_id,
+            "session_id": getattr(result, "session_id", None),
             "status": "ok",
             "results": results_list,
             "errors": errors_list,
+            "usage": [{"name": u.name, "count": u.count} for u in (getattr(result, "usage", None) or [])],
             "warnings": [
                 {"type": w.type, "message": w.message, "detail": getattr(w, "detail", None)} for w in result.warnings
             ]

--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -788,6 +788,17 @@ def search(
             f"Use --mode {new_mode} instead."
         )
 
+    source_policy: dict[str, Any] = {}
+    if include_domains:
+        source_policy["include_domains"] = parse_comma_separated(include_domains)
+    if exclude_domains:
+        source_policy["exclude_domains"] = parse_comma_separated(exclude_domains)
+    domain_total = len(source_policy.get("include_domains", [])) + len(source_policy.get("exclude_domains", []))
+    if domain_total > 200:
+        raise click.UsageError(f"--include-domains and --exclude-domains combined must be <= 200 (got {domain_total}).")
+    if after_date:
+        source_policy["after_date"] = after_date
+
     try:
         from parallel import Parallel
 
@@ -795,19 +806,6 @@ def search(
 
         api_key = get_api_key()
         client = Parallel(api_key=api_key, default_headers=get_default_headers("cli"))
-
-        source_policy: dict[str, Any] = {}
-        if include_domains:
-            source_policy["include_domains"] = parse_comma_separated(include_domains)
-        if exclude_domains:
-            source_policy["exclude_domains"] = parse_comma_separated(exclude_domains)
-        domain_total = len(source_policy.get("include_domains", [])) + len(source_policy.get("exclude_domains", []))
-        if domain_total > 200:
-            raise click.UsageError(
-                f"--include-domains and --exclude-domains combined must be <= 200 (got {domain_total})."
-            )
-        if after_date:
-            source_policy["after_date"] = after_date
 
         fetch_policy: dict[str, Any] = {}
         if max_age_seconds is not None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ from parallel_web_tools.cli.commands import (
     _content_to_markdown,
     _handle_error,
     build_config_from_args,
+    build_extract_v1_kwargs,
+    build_search_v1_kwargs,
     main,
     parse_columns,
     parse_comma_separated,
@@ -991,7 +993,7 @@ class TestSearchCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.search.return_value = mock_search_result
+                mock_client.search.return_value = mock_search_result
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1029,7 +1031,7 @@ class TestSearchCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.search.return_value = mock_search_result
+                mock_client.search.return_value = mock_search_result
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1051,7 +1053,7 @@ class TestSearchCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.search.side_effect = RuntimeError("API unavailable")
+                mock_client.search.side_effect = RuntimeError("API unavailable")
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1070,7 +1072,7 @@ class TestSearchCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.search.side_effect = RuntimeError("API unavailable")
+                mock_client.search.side_effect = RuntimeError("API unavailable")
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1082,6 +1084,474 @@ class TestSearchCommandMocked:
         assert "API unavailable" in result.output
 
 
+class TestBuildSearchV1Kwargs:
+    """Tests for the Beta -> V1 search kwarg translator."""
+
+    def test_minimal_objective_only(self):
+        """Should fall back to using objective as the single search query."""
+        kwargs = build_search_v1_kwargs(
+            objective="latest news on AI",
+            query=(),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["search_queries"] == ["latest news on AI"]
+        assert kwargs["objective"] == "latest news on AI"
+        assert "advanced_settings" not in kwargs
+
+    def test_explicit_queries_override_objective_fallback(self):
+        """Should use explicit queries instead of falling back to objective."""
+        kwargs = build_search_v1_kwargs(
+            objective="overarching goal",
+            query=("first query", "second query"),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["search_queries"] == ["first query", "second query"]
+        assert kwargs["objective"] == "overarching goal"
+
+    def test_mode_fast_maps_to_basic(self):
+        """Should map old `fast` mode to V1 `basic`."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode="fast",
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["mode"] == "basic"
+
+    def test_mode_one_shot_maps_to_basic(self):
+        """Should map old `one-shot` mode to V1 `basic`."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode="one-shot",
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["mode"] == "basic"
+
+    def test_mode_agentic_maps_to_advanced(self):
+        """Should map old `agentic` mode to V1 `advanced`."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode="agentic",
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["mode"] == "advanced"
+
+    def test_new_mode_values_pass_through(self):
+        """Should accept V1-native `basic`/`advanced` values directly."""
+        for new_mode in ("basic", "advanced"):
+            kwargs = build_search_v1_kwargs(
+                objective=None,
+                query=("q",),
+                mode=new_mode,
+                max_results=None,
+                source_policy=None,
+                excerpt_max_chars_per_result=None,
+                excerpt_max_chars_total=None,
+                fetch_policy=None,
+            )
+            assert kwargs["mode"] == new_mode
+
+    def test_excerpt_total_promoted_to_top_level(self):
+        """Should move excerpt_max_chars_total to top-level max_chars_total."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=50000,
+            fetch_policy=None,
+        )
+        assert kwargs["max_chars_total"] == 50000
+
+    def test_excerpt_per_result_nested_under_advanced_settings(self):
+        """Should nest excerpt_max_chars_per_result under advanced_settings.excerpt_settings."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=2000,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 2000}
+
+    def test_max_results_nested_under_advanced_settings(self):
+        """Should nest max_results under advanced_settings."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=25,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["advanced_settings"]["max_results"] == 25
+
+    def test_source_policy_nested_under_advanced_settings(self):
+        """Should nest source_policy under advanced_settings."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=None,
+            source_policy={"include_domains": ["example.com"]},
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["advanced_settings"]["source_policy"] == {"include_domains": ["example.com"]}
+
+    def test_fetch_policy_nested_under_advanced_settings(self):
+        """Should nest fetch_policy under advanced_settings."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy={"max_age_seconds": 3600},
+        )
+        assert kwargs["advanced_settings"]["fetch_policy"] == {"max_age_seconds": 3600}
+
+    def test_location_nested_under_advanced_settings(self):
+        """Should nest location under advanced_settings."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+            location="us",
+        )
+        assert kwargs["advanced_settings"]["location"] == "us"
+
+    def test_session_id_top_level(self):
+        """Should keep session_id at top level."""
+        kwargs = build_search_v1_kwargs(
+            objective=None,
+            query=("q",),
+            mode=None,
+            max_results=None,
+            source_policy=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+            session_id="sess_abc",
+        )
+        assert kwargs["session_id"] == "sess_abc"
+
+    def test_full_translation(self):
+        """Should produce a fully-shaped V1 payload from old-style inputs."""
+        kwargs = build_search_v1_kwargs(
+            objective="find recent papers",
+            query=("transformer architecture",),
+            mode="agentic",
+            max_results=15,
+            source_policy={"include_domains": ["arxiv.org"], "after_date": "2024-01-01"},
+            excerpt_max_chars_per_result=5000,
+            excerpt_max_chars_total=80000,
+            fetch_policy={"max_age_seconds": 7200, "disable_cache_fallback": True},
+            location="us",
+            session_id="sess_xyz",
+        )
+        assert kwargs["search_queries"] == ["transformer architecture"]
+        assert kwargs["objective"] == "find recent papers"
+        assert kwargs["mode"] == "advanced"
+        assert kwargs["max_chars_total"] == 80000
+        assert kwargs["session_id"] == "sess_xyz"
+        adv = kwargs["advanced_settings"]
+        assert adv["max_results"] == 15
+        assert adv["source_policy"]["include_domains"] == ["arxiv.org"]
+        assert adv["source_policy"]["after_date"] == "2024-01-01"
+        assert adv["fetch_policy"] == {"max_age_seconds": 7200, "disable_cache_fallback": True}
+        assert adv["excerpt_settings"] == {"max_chars_per_result": 5000}
+        assert adv["location"] == "us"
+
+
+class TestBuildExtractV1Kwargs:
+    """Tests for the Beta -> V1 extract kwarg translator."""
+
+    def test_minimal_urls_only(self):
+        """Should produce minimal kwargs with just urls."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=False,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs == {"urls": ["https://example.com"]}
+
+    def test_full_content_flag_nests_under_advanced_settings(self):
+        """Should put full_content=True under advanced_settings."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=True,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["advanced_settings"]["full_content"] is True
+
+    def test_full_content_max_chars_takes_precedence(self):
+        """full_content_max_chars should produce a settings dict, overriding the flag."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=True,
+            full_content_max_chars=20000,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["advanced_settings"]["full_content"] == {"max_chars_per_result": 20000}
+
+    def test_excerpt_total_promoted_to_top_level(self):
+        """excerpt_max_chars_total should become top-level max_chars_total."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=False,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=40000,
+            fetch_policy=None,
+        )
+        assert kwargs["max_chars_total"] == 40000
+
+    def test_excerpt_per_result_nested_under_advanced_settings(self):
+        """excerpt_max_chars_per_result nests under advanced_settings.excerpt_settings."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=False,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=3000,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["advanced_settings"]["excerpt_settings"] == {"max_chars_per_result": 3000}
+
+    def test_objective_and_queries_passed_through(self):
+        """Objective and search_queries stay top-level."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective="when was UN founded",
+            query=("united nations history",),
+            full_content=False,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+        )
+        assert kwargs["objective"] == "when was UN founded"
+        assert kwargs["search_queries"] == ["united nations history"]
+
+    def test_session_id_top_level(self):
+        """session_id stays top-level."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=False,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy=None,
+            session_id="sess_abc",
+        )
+        assert kwargs["session_id"] == "sess_abc"
+
+    def test_fetch_policy_nested_under_advanced_settings(self):
+        """fetch_policy nests under advanced_settings."""
+        kwargs = build_extract_v1_kwargs(
+            urls=("https://example.com",),
+            objective=None,
+            query=(),
+            full_content=False,
+            full_content_max_chars=None,
+            excerpt_max_chars_per_result=None,
+            excerpt_max_chars_total=None,
+            fetch_policy={"max_age_seconds": 1200},
+        )
+        assert kwargs["advanced_settings"]["fetch_policy"] == {"max_age_seconds": 1200}
+
+
+class TestSearchDeprecationWarnings:
+    """Tests for deprecation warnings in the search command."""
+
+    def _setup_mock_search(self, mock_client):
+        mock_result = mock.MagicMock()
+        mock_result.search_id = "search_dep"
+        mock_result.results = []
+        mock_result.warnings = []
+        mock_client.search.return_value = mock_result
+
+    @pytest.mark.parametrize(
+        "deprecated_mode,expected_new",
+        [
+            ("fast", "basic"),
+            ("one-shot", "basic"),
+            ("agentic", "advanced"),
+        ],
+    )
+    def test_deprecated_modes_emit_warning_to_stderr(self, runner, deprecated_mode, expected_new):
+        """Should warn on deprecated mode values and translate them."""
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                self._setup_mock_search(mock_client)
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(
+                    main,
+                    ["search", "test", "--mode", deprecated_mode, "--json"],
+                )
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        assert "[deprecated]" in result.stderr
+        assert deprecated_mode in result.stderr
+        assert expected_new in result.stderr
+        # JSON stdout must remain clean
+        json.loads(result.stdout)
+        # SDK call uses translated mode
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs["mode"] == expected_new
+
+    @pytest.mark.parametrize("new_mode", ["basic", "advanced"])
+    def test_new_modes_do_not_emit_warning(self, runner, new_mode):
+        """Should not warn when V1-native mode values are used."""
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                self._setup_mock_search(mock_client)
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(
+                    main,
+                    ["search", "test", "--mode", new_mode, "--json"],
+                )
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        assert "[deprecated]" not in result.stderr
+
+
+class TestExtractDeprecationWarnings:
+    """Tests for deprecation warnings in the extract command."""
+
+    def _setup_mock_extract(self, mock_client, with_excerpts=True):
+        mock_result = mock.MagicMock()
+        mock_result.extract_id = "ext_dep"
+        page = mock.MagicMock()
+        page.url = "https://example.com"
+        page.title = "Example"
+        page.publish_date = None
+        page.excerpts = ["a server-side excerpt"] if with_excerpts else None
+        page.full_content = None
+        mock_result.results = [page]
+        mock_result.errors = []
+        mock_result.warnings = None
+        mock_client.extract.return_value = mock_result
+
+    def test_no_excerpts_emits_warning_and_strips_excerpts_from_output(self, runner):
+        """--no-excerpts should warn (semantics changed) and strip excerpts client-side."""
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                self._setup_mock_extract(mock_client)
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(
+                    main,
+                    ["extract", "https://example.com", "--no-excerpts", "--json"],
+                )
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        assert "[deprecated]" in result.stderr
+        assert "--no-excerpts" in result.stderr
+        output = json.loads(result.stdout)
+        # Excerpts should be stripped from the CLI output
+        assert "excerpts" not in output["results"][0]
+
+    def test_no_no_excerpts_keeps_excerpts_and_no_warning(self, runner):
+        """Default extract should not warn and should include excerpts."""
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                self._setup_mock_extract(mock_client)
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(
+                    main,
+                    ["extract", "https://example.com", "--json"],
+                )
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        assert "[deprecated]" not in result.stderr
+        output = json.loads(result.stdout)
+        assert output["results"][0]["excerpts"] == ["a server-side excerpt"]
+
+
 class TestExtractCommandMocked:
     """Tests for the extract command with mocked Parallel SDK."""
 
@@ -1091,7 +1561,7 @@ class TestExtractCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.extract.side_effect = ConnectionError("Network error")
+                mock_client.extract.side_effect = ConnectionError("Network error")
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1122,7 +1592,7 @@ class TestExtractCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.extract.return_value = mock_extract_result
+                mock_client.extract.return_value = mock_extract_result
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1161,7 +1631,7 @@ class TestExtractCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.extract.return_value = mock_extract_result
+                mock_client.extract.return_value = mock_extract_result
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 
@@ -1194,7 +1664,7 @@ class TestExtractCommandMocked:
             with mock.patch.dict("sys.modules"):
                 mock_parallel_mod = mock.MagicMock()
                 mock_client = mock.MagicMock()
-                mock_client.beta.extract.return_value = mock_extract_result
+                mock_client.extract.return_value = mock_extract_result
                 mock_parallel_mod.Parallel.return_value = mock_client
                 sys.modules["parallel"] = mock_parallel_mod
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -987,6 +987,8 @@ class TestSearchCommandMocked:
                 excerpts=["An excerpt"],
             )
         ]
+        mock_search_result.session_id = None
+        mock_search_result.usage = None
         mock_search_result.warnings = []
 
         with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
@@ -1025,6 +1027,8 @@ class TestSearchCommandMocked:
         warning_obj.type = "warning"
         warning_obj.message = "Excerpts truncated to 500 characters"
         warning_obj.detail = {"max_chars_total": 500}
+        mock_search_result.session_id = None
+        mock_search_result.usage = None
         mock_search_result.warnings = [warning_obj]
 
         with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
@@ -1421,13 +1425,144 @@ class TestBuildExtractV1Kwargs:
         assert kwargs["advanced_settings"]["fetch_policy"] == {"max_age_seconds": 1200}
 
 
+class TestSearchExtractV1Validation:
+    """Tests for V1 input validation (URL count, objective length, domain count)."""
+
+    def test_extract_rejects_more_than_20_urls(self, runner):
+        """V1 caps URLs at 20; extra URLs should fail fast with a clear message."""
+        urls = [f"https://example.com/{i}" for i in range(21)]
+        result = runner.invoke(main, ["extract", *urls, "--json"])
+        assert result.exit_code != 0
+        assert "20 URLs" in result.output
+
+    def test_extract_accepts_exactly_20_urls(self, runner):
+        """At-the-limit case should not be blocked by the check."""
+        urls = [f"https://example.com/{i}" for i in range(20)]
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                mock_result = mock.MagicMock()
+                mock_result.extract_id = "ext_20"
+                mock_result.session_id = None
+                mock_result.results = []
+                mock_result.errors = []
+                mock_result.usage = None
+                mock_result.warnings = None
+                mock_client.extract.return_value = mock_result
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(main, ["extract", *urls, "--json"])
+
+                del sys.modules["parallel"]
+        assert result.exit_code == 0
+
+    def test_extract_rejects_objective_over_5000_chars(self, runner):
+        """V1 caps objective at 5000 characters."""
+        long_obj = "a" * 5001
+        result = runner.invoke(main, ["extract", "https://example.com", "--objective", long_obj, "--json"])
+        assert result.exit_code != 0
+        assert "5000 characters" in result.output
+
+    def test_search_rejects_combined_domain_count_over_200(self, runner):
+        """V1 caps include + exclude domains combined at 200."""
+        domains = ",".join(f"example{i}.com" for i in range(150))
+        more_domains = ",".join(f"other{i}.com" for i in range(60))
+        result = runner.invoke(
+            main,
+            [
+                "search",
+                "test",
+                "--include-domains",
+                domains,
+                "--exclude-domains",
+                more_domains,
+                "--json",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "200" in result.output
+
+
+class TestV1ResponseFieldsSurfaced:
+    """Tests that V1 response fields (session_id, usage) are surfaced in output."""
+
+    def test_search_output_includes_session_id_and_usage(self, runner):
+        """Search output should include session_id and usage fields when present."""
+        mock_result = mock.MagicMock()
+        mock_result.search_id = "search_v1"
+        mock_result.session_id = "sess_xyz"
+        mock_result.results = []
+        usage_item = mock.MagicMock()
+        usage_item.name = "search_basic"
+        usage_item.count = 1
+        mock_result.usage = [usage_item]
+        mock_result.warnings = []
+
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                mock_client.search.return_value = mock_result
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(main, ["search", "test", "--json"])
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["session_id"] == "sess_xyz"
+        assert output["usage"] == [{"name": "search_basic", "count": 1}]
+
+    def test_extract_output_includes_session_id_and_usage(self, runner):
+        """Extract output should include session_id and usage fields when present."""
+        mock_result = mock.MagicMock()
+        mock_result.extract_id = "ext_v1"
+        mock_result.session_id = "sess_abc"
+        page = mock.MagicMock()
+        page.url = "https://example.com"
+        page.title = "Example"
+        page.publish_date = None
+        page.excerpts = []
+        page.full_content = None
+        mock_result.results = [page]
+        mock_result.errors = []
+        usage_item = mock.MagicMock()
+        usage_item.name = "extract"
+        usage_item.count = 1
+        mock_result.usage = [usage_item]
+        mock_result.warnings = None
+
+        with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
+            with mock.patch.dict("sys.modules"):
+                mock_parallel_mod = mock.MagicMock()
+                mock_client = mock.MagicMock()
+                mock_client.extract.return_value = mock_result
+                mock_parallel_mod.Parallel.return_value = mock_client
+                sys.modules["parallel"] = mock_parallel_mod
+
+                result = runner.invoke(main, ["extract", "https://example.com", "--json"])
+
+                del sys.modules["parallel"]
+
+        assert result.exit_code == 0
+        output = json.loads(result.stdout)
+        assert output["session_id"] == "sess_abc"
+        assert output["usage"] == [{"name": "extract", "count": 1}]
+
+
 class TestSearchDeprecationWarnings:
     """Tests for deprecation warnings in the search command."""
 
     def _setup_mock_search(self, mock_client):
         mock_result = mock.MagicMock()
         mock_result.search_id = "search_dep"
+        mock_result.session_id = None
         mock_result.results = []
+        mock_result.usage = None
         mock_result.warnings = []
         mock_client.search.return_value = mock_result
 
@@ -1494,6 +1629,7 @@ class TestExtractDeprecationWarnings:
     def _setup_mock_extract(self, mock_client, with_excerpts=True):
         mock_result = mock.MagicMock()
         mock_result.extract_id = "ext_dep"
+        mock_result.session_id = None
         page = mock.MagicMock()
         page.url = "https://example.com"
         page.title = "Example"
@@ -1502,6 +1638,7 @@ class TestExtractDeprecationWarnings:
         page.full_content = None
         mock_result.results = [page]
         mock_result.errors = []
+        mock_result.usage = None
         mock_result.warnings = None
         mock_client.extract.return_value = mock_result
 
@@ -1586,6 +1723,8 @@ class TestExtractCommandMocked:
         mock_page.full_content = None
         mock_extract_result.results = [mock_page]
         mock_extract_result.errors = []
+        mock_extract_result.session_id = None
+        mock_extract_result.usage = None
         mock_extract_result.warnings = None
 
         with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
@@ -1625,6 +1764,8 @@ class TestExtractCommandMocked:
         warning_obj.type = "input_validation_warning"
         warning_obj.message = "Excerpts truncated"
         warning_obj.detail = {"max_chars_total": 500}
+        mock_extract_result.session_id = None
+        mock_extract_result.usage = None
         mock_extract_result.warnings = [warning_obj]
 
         with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):
@@ -1658,6 +1799,8 @@ class TestExtractCommandMocked:
         mock_error.http_status_code = 500
         mock_error.content = "Internal Server Error"
         mock_extract_result.errors = [mock_error]
+        mock_extract_result.session_id = None
+        mock_extract_result.usage = None
         mock_extract_result.warnings = None
 
         with mock.patch("parallel_web_tools.cli.commands.get_api_key", return_value="test-key"):

--- a/uv.lock
+++ b/uv.lock
@@ -1382,7 +1382,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web"
-version = "0.4.2"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1392,9 +1392,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/50/fb9b28a679e01682006b5259abff96de3d16e114e9447a7793fec31715de/parallel_web-0.4.2.tar.gz", hash = "sha256:599b5a8f387dc35c7dc8c81e372eadf6958a40acacea58bf170dfc663c003da7", size = 140026, upload-time = "2026-03-09T22:24:35.448Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/35/55355e4d748959973bb921dc6547834cb16f732ab209fcc2bb1d69ec195f/parallel_web-0.5.1.tar.gz", hash = "sha256:e967f3bd1833c73db30ea11aa49f5b3248c10342af1fa768a4a290ff8f4301f6", size = 154941, upload-time = "2026-04-22T18:03:38.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/3e/2218fa29637781b8e7ac35a928108ff2614ddd40879389d3af2caa725af5/parallel_web-0.4.2-py3-none-any.whl", hash = "sha256:aa3a4a9aecc08972c5ce9303271d4917903373dff4dd277d9a3e30f9cff53346", size = 144012, upload-time = "2026-03-09T22:24:33.979Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d7/2bcad8a9c6c878439bf922e49d82a3ef31e63ae323cbaab4ed9b2ec15c03/parallel_web-0.5.1-py3-none-any.whl", hash = "sha256:7db65556a362d44ae864b5e4881a239e96377bcefbf931616d9c3b80a6124c21", size = 164287, upload-time = "2026-04-22T18:03:36.854Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps `parallel-web` 0.4.2 → 0.5.1 and migrates the CLI `search` and `extract` commands from the Beta API (`client.beta.search/extract`) to the V1 API (`client.search/extract`) per the [search](https://docs.parallel.ai/search/search-migration-guide) and [extract](https://docs.parallel.ai/extract/extract-migration-guide) migration guides.

Backwards compatibility for existing CLI users is preserved by translating old-style flags into the V1 SDK shape; deprecated values emit a notice to stderr so users know they will need to update before the Beta API sunset (June 2026).

## Search command

- `--mode` keeps accepting Beta values (`fast`, `one-shot`, `agentic`) and translates them: `fast`/`one-shot` → `basic`, `agentic` → `advanced`. V1-native (`basic`, `advanced`) values pass through.
- `excerpt_max_chars_total` moves to top-level `max_chars_total` per V1.
- `excerpt_max_chars_per_result`, `max_results`, `source_policy`, `fetch_policy` are now nested under `advanced_settings`.
- `search_queries` is required by V1; if the user only passes an `OBJECTIVE` (no `--query`), we use the objective as the single query so old invocations keep working.
- New flags: `--location` (ISO 3166-1 alpha-2 country code for geo-targeted results), `--session-id`.

## Extract command

- `excerpt_max_chars_total` moves to top-level `max_chars_total`.
- `excerpt_max_chars_per_result`, `full_content`, `fetch_policy` nested under `advanced_settings`.
- `--no-excerpts` can no longer disable excerpts server-side (V1 always returns them). The flag now strips them from CLI output.
- New flag: `--session-id`.

## Deprecation notices

When a user passes a deprecated `--mode` value or uses `--no-excerpts`, a `[deprecated] ...` note goes to **stderr** so JSON on stdout stays clean for piping.

```
$ parallel-cli search "..." --mode fast --json
[deprecated] --mode fast is a Beta value and will stop working after the Beta API sunset (June 2026). Use --mode basic instead.
{"search_id": "...", ...}
```

## Translation layer

Translation lives in two helpers — `build_search_v1_kwargs` and `build_extract_v1_kwargs` — so it can be unit-tested independent of the Click plumbing.

## Test plan

### Static
- [x] `uv run pytest` — 631 passed (29 new)
- [x] `uv run pre-commit run --all-files` — ruff + ty pass

### Live API matrix — search
- [x] Modes: `fast`, `one-shot`, `agentic`, `basic`, `advanced` (deprecation notice fires only for the 3 Beta values; all 5 produce results)
- [x] Inputs: objective only (V1 query fallback), `--query` only, both together, multiple `--query`, stdin `-`, no-args error
- [x] Filters: `--include-domains` (single + comma-separated + repeated), `--exclude-domains`, `--after-date` (returned 2026-04-29 result), `--max-age-seconds` + `--timeout-seconds`
- [x] V1 features: `--location de` (returned Germany content), `--session-id`
- [x] Output: `--json`, `-o FILE`, console (non-JSON) rendering — schema unchanged from Beta era

### Live API matrix — extract
- [x] Single URL, 3 URLs in one call (V1 supports up to 20)
- [x] `--full-content` (returned 29k chars), `--full-content-max-chars 2000` (capped to exactly 2000)
- [x] `--objective` + `--query` (focused excerpts)
- [x] `fetch` alias still works
- [x] `--no-excerpts` strips client-side; deprecation notice fires
- [x] Error path: bogus DNS → `errors: [{error_type: "dns_error", ...}]`
- [x] V1 features: `--session-id`

### Cross-integration safety check (other extras still work with parallel-web 0.5.1)
- [x] Direct test files: `test_duckdb.py`, `test_polars.py`, `test_spark.py`, `test_user_agent.py` — 103/103 pass
- [x] All 9 integration modules import clean (`duckdb.batch/findall/udf`, `polars.enrich`, `spark.udf/streaming`, `snowflake.deploy`, `bigquery.deploy`, `integrations.utils`)
- [x] `beta.task_group` end-to-end: ran `enrich` against the live API on a 2-row dataset (lite-fast); created task group, polled to completion, returned correct CEO names
- [x] `beta.findall` end-to-end: `create` + `retrieve` (poll) + `result` against the live API; returned a real candidate (Warp, ~12k GitHub stars, MIT/Apache-2.0 Rust web framework) with `is_matched: true` on all conditions

## New tests

- `TestBuildSearchV1Kwargs` — 13 tests covering mode mapping, advanced_settings nesting, and full payload shape
- `TestBuildExtractV1Kwargs` — 8 tests covering the same for extract
- `TestSearchDeprecationWarnings` — parametrized over all deprecated/new modes; verifies stderr/stdout split
- `TestExtractDeprecationWarnings` — verifies `--no-excerpts` warning + client-side excerpt stripping