### PR TITLE
Add a skills management command to parallel cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -62,6 +62,9 @@ jobs:
 
       - name: Check formatting with ruff
         run: uv run ruff format --check parallel_web_tools/ tests/
+
+      - name: Architecture check with tach
+        run: uv run tach check
 
       - name: Type check with ty
         run: uv run ty check
@@ -76,7 +79,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ wheels/
 # Environment files
 .env.local
 .env
+.envrc
+.direnv
 
 # Data files
 data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
-    - id: check-merge-conflict
-    - id: debug-statements
-    - id: end-of-file-fixer
-    - id: detect-private-key
-    - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: detect-private-key
+      - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.14
     hooks:
@@ -16,6 +16,12 @@ repos:
       - id: ruff-format
   - repo: local
     hooks:
+      - id: tach-check
+        name: tach check
+        entry: uv run tach check
+        language: system
+        pass_filenames: false
+        types: [python]
       - id: ty-check
         name: ty (type checking)
         entry: uv run ty check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Guidance for coding agents working in this repository.
+
+## Recommended iteration cycle after code changes
+
+Run commands from the repository root.
+
+### 1) Autofix lint issues first
+
+```bash
+uv run ruff check --fix .
+```
+
+### 2) Format code
+
+```bash
+uv run ruff format .
+```
+
+### 3) Run architecture checks
+
+```bash
+uv run tach check
+```
+
+If `tach check` fails, do not immediately restructure modules or change dependency boundaries on your own. Confirm with the user before making architectural fixes, since Tach failures can imply intended or unintended module boundary changes.
+
+### 4) Run type checks
+
+```bash
+uv run ty check
+```
+
+### 5) Run tests
+
+For targeted changes, run the relevant test files first:
+
+```bash
+uv run pytest -q tests/test_cli.py tests/test_skills.py
+```
+
+For broader changes or before finishing, run the full test suite:
+
+```bash
+uv run pytest -q
+```
+
+## Expectations
+
+- Prefer `uv run ruff check --fix .` before manual cleanup.
+- Run `uv run tach check` after code changes that may affect imports or module boundaries.
+- If `uv run tach check` fails, confirm with the user before making architectural/module-layout fixes.
+- Run targeted tests during iteration for faster feedback.
+- Run the full relevant validation before finishing work.
+- If a command fails, fix the reported issues before finishing.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,14 +8,13 @@ From the repository root:
 
 ## Install Option 1: Nix
 
-Put in the repo a envrc file with the following contents:
-`.envrc`
+Create a `.envrc` file in the repo root containing:
 
 ```
 use flake;
 ```
 
-## Install Option 2:
+## Install Option 2: Manual
 
 Make sure you have the following installed:
 
@@ -26,7 +25,7 @@ Make sure you have the following installed:
 
 ## First time setup
 
-Sets up python and install all deps, and setup pre-commit:
+Sets up Python, installs all dev dependencies, and sets up pre-commit:
 
 ```bash
 uv sync --extra dev
@@ -48,7 +47,10 @@ uv run parallel-cli
 
 If you want to build the binary for whatever reason:
 
-```
+```bash
+# If you only need build tooling, this is enough:
+uv sync --extra build
+
 uv run python scripts/build.py
 ```
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,6 +2,56 @@
 
 Instructions for releasing and maintaining the parallel-web-tools package.
 
+# Development Setup
+
+From the repository root:
+
+## Install Option 1: Nix
+
+Put in the repo a envrc file with the following contents:
+`.envrc`
+
+```
+use flake;
+```
+
+## Install Option 2:
+
+Make sure you have the following installed:
+
+- uv
+- Python 3.12
+- Node 24
+- pnpm
+
+## First time setup
+
+Sets up python and install all deps, and setup pre-commit:
+
+```bash
+uv sync --extra dev
+
+# Install git hooks
+uv run pre-commit install
+
+# Run hooks manually on all files
+uv run pre-commit run --all-files
+```
+
+## Running development version of parallel-cli
+
+Just run:
+
+```
+uv run parallel-cli
+```
+
+If you want to build the binary for whatever reason:
+
+```
+uv run python scripts/build.py
+```
+
 ## Release Process
 
 ### Quick Release (Recommended)
@@ -20,12 +70,14 @@ From the `main` branch with a clean working tree:
 ```
 
 This script will:
+
 1. Calculate the next version
 2. Update all 4 version files
 3. Create a `release/vX.Y.Z` branch
 4. Commit, push, and open a PR
 
 After you merge the PR, everything else is automated:
+
 - `auto-release.yml` detects the version bump commit and creates a GitHub Release + tag
 - `release.yml` builds standalone binaries for all platforms
 - `publish.yml` publishes to PyPI
@@ -34,6 +86,7 @@ After you merge the PR, everything else is automated:
 ### Manual Version Update (if needed)
 
 Update the version in these places:
+
 - `pyproject.toml`: `version = "X.Y.Z"`
 - `parallel_web_tools/__init__.py`: `__version__ = "X.Y.Z"`
 - `parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt`: `parallel-web-tools>=X.Y.Z`
@@ -64,24 +117,14 @@ parallel-cli --version
 
 ### Supported Platforms
 
-| Platform | Runner | Archive Name |
-|----------|--------|--------------|
-| macOS Apple Silicon | `macos-15` | `parallel-cli-darwin-arm64.zip` |
-| macOS Intel | `macos-15-large` | `parallel-cli-darwin-x64.zip` |
-| Linux x64 | `ubuntu-latest` | `parallel-cli-linux-x64.zip` |
-| Windows x64 | `windows-latest` | `parallel-cli-windows-x64.zip` |
+| Platform            | Runner           | Archive Name                    |
+| ------------------- | ---------------- | ------------------------------- |
+| macOS Apple Silicon | `macos-15`       | `parallel-cli-darwin-arm64.zip` |
+| macOS Intel         | `macos-15-large` | `parallel-cli-darwin-x64.zip`   |
+| Linux x64           | `ubuntu-latest`  | `parallel-cli-linux-x64.zip`    |
+| Windows x64         | `windows-latest` | `parallel-cli-windows-x64.zip`  |
 
 Note: Linux arm64 is not supported (no GitHub-hosted ARM64 runners available).
-
-### Local Build
-
-```bash
-# Build for current platform
-uv run scripts/build.py
-
-# Test the binary (onedir mode - binary is in a folder)
-./dist/parallel-cli/parallel-cli --version
-```
 
 ### Binary Size
 
@@ -104,6 +147,7 @@ Configure trusted publishing (no API tokens needed):
    - Environment name: `pypi`
 
 For Test PyPI (recommended for testing):
+
 1. Go to https://test.pypi.org/manage/account/publishing/
 2. Same steps, but use environment name: `test-pypi`
 
@@ -144,6 +188,7 @@ git push origin --delete v0.0.1-test
 ### Pre-releases
 
 For testing without affecting "latest":
+
 1. Create release as usual
 2. Check **Set as a pre-release**
 
@@ -187,12 +232,12 @@ python scripts/update-homebrew-formula.py --version 0.1.2 --output homebrew/para
 
 ## CI/CD Workflows
 
-| Workflow | Trigger | Purpose |
-|----------|---------|---------|
-| `ci.yml` | Push to main, PRs | Run tests and type checking |
-| `auto-release.yml` | Push to main (version bump commits) | Create tag + GitHub Release |
-| `release.yml` | Release created | Build binaries, publish to npm + Homebrew |
-| `publish.yml` | Release published | Publish to PyPI |
+| Workflow           | Trigger                             | Purpose                                   |
+| ------------------ | ----------------------------------- | ----------------------------------------- |
+| `ci.yml`           | Push to main, PRs                   | Run tests and type checking               |
+| `auto-release.yml` | Push to main (version bump commits) | Create tag + GitHub Release               |
+| `release.yml`      | Release created                     | Build binaries, publish to npm + Homebrew |
+| `publish.yml`      | Release published                   | Publish to PyPI                           |
 
 ### Manually Trigger Workflows
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -48,9 +48,6 @@ uv run parallel-cli
 If you want to build the binary for whatever reason:
 
 ```bash
-# If you only need build tooling, this is enough:
-uv sync --extra build
-
 uv run python scripts/build.py
 ```
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777826146,
+        "narHash": "sha256-wQ/iN5Zp5VIa3ebBibijPnLyKhor+xEbDy4d0goa9Zs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "73c703c22422b8951895a960959dbbaca7296492",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,12 @@
         };
 
         shellHook = ''
-          export PATH="$PWD/.venv/bin:$PATH"
+          if command -v git >/dev/null 2>&1; then
+            REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+          else
+            REPO_ROOT="$PWD"
+          fi
+          export PATH="$REPO_ROOT/.venv/bin:$PATH"
 
           echo "parallel-web-tools dev shell"
           echo "python: $(python --version 2>/dev/null)"

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,54 @@
+{
+  description = "Nix flake for parallel-web-tools development";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+
+      python = pkgs.python312;
+
+      basePackages = with pkgs; [
+        python
+        uv
+        nodejs_24
+        pnpm
+      ];
+    in {
+      devShells.default = pkgs.mkShell {
+        packages = basePackages;
+
+        env = {
+          UV_PYTHON = "${python}/bin/python3";
+        };
+
+        shellHook = ''
+          export PATH="$PWD/.venv/bin:$PATH"
+
+          echo "parallel-web-tools dev shell"
+          echo "python: $(python --version 2>/dev/null)"
+          echo "uv: $(uv --version 2>/dev/null)"
+          echo "node: $(node --version 2>/dev/null)"
+          echo
+          echo "Suggested setup:"
+          echo "  uv sync --extra dev"
+          echo "  uv run pre-commit install"
+          echo "  uv run parallel-cli --help"
+
+          echo "To build a binary"
+          echo "  uv run python scripts/build.py"
+        '';
+      };
+    });
+}

--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -7,7 +7,7 @@ import os
 import sys
 import tempfile
 import time
-from typing import Any
+from typing import Any, NoReturn
 
 import click
 import httpx
@@ -170,7 +170,7 @@ def _handle_error(
     output_json: bool = False,
     exit_code: int = EXIT_API_ERROR,
     prefix: str = "Error",
-) -> None:
+) -> NoReturn:
     """Handle an error with appropriate output format and exit code.
 
     In --json mode, outputs structured JSON to stdout. Otherwise, prints a
@@ -645,6 +645,135 @@ def config_cmd(key: str | None, value: str | None, output_json: bool):
             print(json.dumps({key: is_auto_update_check_enabled()}, indent=2))
         else:
             console.print(f"[green]Set {key} = {format_bool(is_auto_update_check_enabled())}[/green]")
+
+
+# =============================================================================
+# Skills Commands
+# =============================================================================
+
+
+@main.group()
+def skills():
+    """Install and manage Parallel agent skills."""
+    pass
+
+
+@skills.command(name="install")
+@click.option(
+    "--project",
+    is_flag=True,
+    help="Install to .agents/skills in detected project root (default is global install).",
+)
+@click.option("--skill", "skill_names", multiple=True, help="Skill name to install (repeatable). Defaults to all.")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def skills_install(project: bool, skill_names: tuple[str, ...], output_json: bool):
+    """Install Parallel skills from GitHub."""
+    from parallel_web_tools.core.skills import (
+        SkillsError,
+        SkillsInstallLocationError,
+        get_skills_repo_ref,
+        install_skills,
+        resolve_install_dir,
+    )
+
+    try:
+        install_dir = resolve_install_dir(project=project)
+        result = install_skills(
+            install_dir=install_dir,
+            selected_skills=list(skill_names) or None,
+            ref=get_skills_repo_ref(),
+        )
+    except SkillsInstallLocationError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Skills install failed")
+    except SkillsError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills install failed")
+    except Exception as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills install failed")
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    console.print("[bold green]Skills installed[/bold green]")
+    console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+    console.print(f"Ref: [cyan]{result['ref']}[/cyan]")
+    console.print(f"Installed ({result['count']}): [cyan]{', '.join(result['installed_skills'])}[/cyan]")
+
+
+@skills.command(name="uninstall")
+@click.option(
+    "--project",
+    is_flag=True,
+    help="Uninstall from .agents/skills in detected project root (default is global install).",
+)
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def skills_uninstall(project: bool, output_json: bool):
+    """Uninstall skills previously installed by parallel-cli."""
+    from parallel_web_tools.core.skills import SkillsInstallLocationError, resolve_install_dir, uninstall_skills
+
+    try:
+        install_dir = resolve_install_dir(project=project)
+        result = uninstall_skills(install_dir=install_dir)
+    except SkillsInstallLocationError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Skills uninstall failed")
+    except Exception as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills uninstall failed")
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    if result["count"] == 0:
+        console.print("[yellow]No managed skills found to uninstall[/yellow]")
+        console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+        return
+
+    console.print("[bold green]Skills uninstalled[/bold green]")
+    console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+    console.print(f"Removed ({result['count']}): [cyan]{', '.join(result['removed_skills'])}[/cyan]")
+
+
+@skills.command(name="reinstall")
+@click.option(
+    "--project",
+    is_flag=True,
+    help="Reinstall in .agents/skills in detected project root (default is global install).",
+)
+@click.option("--skill", "skill_names", multiple=True, help="Skill name to reinstall (repeatable). Defaults to all.")
+@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+def skills_reinstall(project: bool, skill_names: tuple[str, ...], output_json: bool):
+    """Reinstall Parallel skills (uninstall managed set then install fresh)."""
+    from parallel_web_tools.core.skills import (
+        SkillsError,
+        SkillsInstallLocationError,
+        get_skills_repo_ref,
+        reinstall_skills,
+        resolve_install_dir,
+    )
+
+    try:
+        install_dir = resolve_install_dir(project=project)
+        result = reinstall_skills(
+            install_dir=install_dir,
+            selected_skills=list(skill_names) or None,
+            ref=get_skills_repo_ref(),
+        )
+    except SkillsInstallLocationError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Skills reinstall failed")
+    except SkillsError as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills reinstall failed")
+    except Exception as e:
+        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills reinstall failed")
+
+    if output_json:
+        print(json.dumps(result, indent=2))
+        return
+
+    console.print("[bold green]Skills reinstalled[/bold green]")
+    console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+    console.print(f"Ref: [cyan]{result['ref']}[/cyan]")
+    console.print(f"Removed ({result['removed_count']}): [cyan]{', '.join(result['removed_skills'])}[/cyan]")
+    console.print(f"Installed ({result['installed_count']}): [cyan]{', '.join(result['installed_skills'])}[/cyan]")
 
 
 # =============================================================================

--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 from rich.console import Console
 
 from parallel_web_tools import __version__
+from parallel_web_tools.cli.skills import create_skills_group
 from parallel_web_tools.core import (
     AVAILABLE_PROCESSORS,
     FINDALL_GENERATORS,
@@ -647,133 +648,7 @@ def config_cmd(key: str | None, value: str | None, output_json: bool):
             console.print(f"[green]Set {key} = {format_bool(is_auto_update_check_enabled())}[/green]")
 
 
-# =============================================================================
-# Skills Commands
-# =============================================================================
-
-
-@main.group()
-def skills():
-    """Install and manage Parallel agent skills."""
-    pass
-
-
-@skills.command(name="install")
-@click.option(
-    "--project",
-    is_flag=True,
-    help="Install to .agents/skills in detected project root (default is global install).",
-)
-@click.option("--skill", "skill_names", multiple=True, help="Skill name to install (repeatable). Defaults to all.")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-def skills_install(project: bool, skill_names: tuple[str, ...], output_json: bool):
-    """Install Parallel skills from GitHub."""
-    from parallel_web_tools.core.skills import (
-        SkillsError,
-        SkillsInstallLocationError,
-        get_skills_repo_ref,
-        install_skills,
-        resolve_install_dir,
-    )
-
-    try:
-        install_dir = resolve_install_dir(project=project)
-        result = install_skills(
-            install_dir=install_dir,
-            selected_skills=list(skill_names) or None,
-            ref=get_skills_repo_ref(),
-        )
-    except SkillsInstallLocationError as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Skills install failed")
-    except SkillsError as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills install failed")
-    except Exception as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills install failed")
-
-    if output_json:
-        print(json.dumps(result, indent=2))
-        return
-
-    console.print("[bold green]Skills installed[/bold green]")
-    console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
-    console.print(f"Ref: [cyan]{result['ref']}[/cyan]")
-    console.print(f"Installed ({result['count']}): [cyan]{', '.join(result['installed_skills'])}[/cyan]")
-
-
-@skills.command(name="uninstall")
-@click.option(
-    "--project",
-    is_flag=True,
-    help="Uninstall from .agents/skills in detected project root (default is global install).",
-)
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-def skills_uninstall(project: bool, output_json: bool):
-    """Uninstall skills previously installed by parallel-cli."""
-    from parallel_web_tools.core.skills import SkillsInstallLocationError, resolve_install_dir, uninstall_skills
-
-    try:
-        install_dir = resolve_install_dir(project=project)
-        result = uninstall_skills(install_dir=install_dir)
-    except SkillsInstallLocationError as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Skills uninstall failed")
-    except Exception as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills uninstall failed")
-
-    if output_json:
-        print(json.dumps(result, indent=2))
-        return
-
-    if result["count"] == 0:
-        console.print("[yellow]No managed skills found to uninstall[/yellow]")
-        console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
-        return
-
-    console.print("[bold green]Skills uninstalled[/bold green]")
-    console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
-    console.print(f"Removed ({result['count']}): [cyan]{', '.join(result['removed_skills'])}[/cyan]")
-
-
-@skills.command(name="reinstall")
-@click.option(
-    "--project",
-    is_flag=True,
-    help="Reinstall in .agents/skills in detected project root (default is global install).",
-)
-@click.option("--skill", "skill_names", multiple=True, help="Skill name to reinstall (repeatable). Defaults to all.")
-@click.option("--json", "output_json", is_flag=True, help="Output as JSON")
-def skills_reinstall(project: bool, skill_names: tuple[str, ...], output_json: bool):
-    """Reinstall Parallel skills (uninstall managed set then install fresh)."""
-    from parallel_web_tools.core.skills import (
-        SkillsError,
-        SkillsInstallLocationError,
-        get_skills_repo_ref,
-        reinstall_skills,
-        resolve_install_dir,
-    )
-
-    try:
-        install_dir = resolve_install_dir(project=project)
-        result = reinstall_skills(
-            install_dir=install_dir,
-            selected_skills=list(skill_names) or None,
-            ref=get_skills_repo_ref(),
-        )
-    except SkillsInstallLocationError as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_BAD_INPUT, prefix="Skills reinstall failed")
-    except SkillsError as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills reinstall failed")
-    except Exception as e:
-        _handle_error(e, output_json=output_json, exit_code=EXIT_API_ERROR, prefix="Skills reinstall failed")
-
-    if output_json:
-        print(json.dumps(result, indent=2))
-        return
-
-    console.print("[bold green]Skills reinstalled[/bold green]")
-    console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
-    console.print(f"Ref: [cyan]{result['ref']}[/cyan]")
-    console.print(f"Removed ({result['removed_count']}): [cyan]{', '.join(result['removed_skills'])}[/cyan]")
-    console.print(f"Installed ({result['installed_count']}): [cyan]{', '.join(result['installed_skills'])}[/cyan]")
+main.add_command(create_skills_group(console, _handle_error, EXIT_BAD_INPUT, EXIT_API_ERROR))
 
 
 # =============================================================================

--- a/parallel_web_tools/cli/skills.py
+++ b/parallel_web_tools/cli/skills.py
@@ -1,0 +1,204 @@
+"""Skills CLI commands for parallel-cli."""
+
+from __future__ import annotations
+
+import json
+from typing import NoReturn, Protocol
+
+import click
+from rich.console import Console
+
+
+class HandleError(Protocol):
+    def __call__(
+        self,
+        error: Exception,
+        output_json: bool = False,
+        exit_code: int = 0,
+        prefix: str = "Error",
+    ) -> NoReturn: ...
+
+
+def create_skills_group(
+    console: Console,
+    handle_error: HandleError,
+    exit_bad_input: int,
+    exit_api_error: int,
+) -> click.Group:
+    """Create the skills command group.
+
+    Keeps feature-specific command wiring out of ``commands.py`` while retaining
+    lazy imports of the underlying skills implementation.
+    """
+
+    @click.group(name="skills")
+    def skills() -> None:
+        """Install and manage Parallel agent skills.
+
+        Set GH_TOKEN for higher GitHub API rate limits when fetching skills.
+        """
+        pass
+
+    @skills.command(name="list")
+    @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+    def skills_list(output_json: bool) -> None:
+        """List available Parallel skills from GitHub."""
+        from parallel_web_tools.core.skills import SkillsError, get_skills_repo_ref, list_remote_skills
+
+        try:
+            ref = get_skills_repo_ref()
+            skill_names = list_remote_skills(ref=ref)
+        except SkillsError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills list failed")
+        except Exception as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills list failed")
+
+        if output_json:
+            print(json.dumps({"ref": ref, "skills": skill_names, "count": len(skill_names)}, indent=2))
+            return
+
+        console.print("[bold]Available skills[/bold]")
+        console.print(f"Ref: [cyan]{ref}[/cyan]")
+        for skill_name in skill_names:
+            console.print(f"- [cyan]{skill_name}[/cyan]")
+
+    @skills.command(name="install")
+    @click.option(
+        "--project",
+        is_flag=True,
+        help="Install to .agents/skills in detected project root (default is global install).",
+    )
+    @click.option(
+        "--skill",
+        "skill_names",
+        multiple=True,
+        help="Skill name to install (repeatable). Defaults to all. Skills not listed will be removed.",
+    )
+    @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+    def skills_install(project: bool, skill_names: tuple[str, ...], output_json: bool) -> None:
+        """Install Parallel skills from GitHub.
+
+        When --skill is provided, the managed install set is replaced with exactly
+        the listed skills.
+        """
+        from parallel_web_tools.core.skills import (
+            SkillsError,
+            SkillsInputError,
+            SkillsInstallLocationError,
+            get_skills_repo_ref,
+            install_skills,
+            resolve_install_dir,
+        )
+
+        try:
+            install_dir = resolve_install_dir(project=project)
+            result = install_skills(
+                install_dir=install_dir,
+                selected_skills=list(skill_names) or None,
+                ref=get_skills_repo_ref(),
+            )
+        except SkillsInstallLocationError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_bad_input, prefix="Skills install failed")
+        except SkillsInputError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_bad_input, prefix="Skills install failed")
+        except SkillsError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills install failed")
+        except Exception as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills install failed")
+
+        if output_json:
+            print(json.dumps(result, indent=2))
+            return
+
+        console.print("[bold green]Skills installed[/bold green]")
+        console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+        console.print(f"Ref: [cyan]{result['ref']}[/cyan]")
+        console.print(f"Installed ({result['count']}): [cyan]{', '.join(result['installed_skills'])}[/cyan]")
+
+    @skills.command(name="uninstall")
+    @click.option(
+        "--project",
+        is_flag=True,
+        help="Uninstall from .agents/skills in detected project root (default is global install).",
+    )
+    @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+    def skills_uninstall(project: bool, output_json: bool) -> None:
+        """Uninstall skills previously installed by parallel-cli."""
+        from parallel_web_tools.core.skills import SkillsInstallLocationError, resolve_install_dir, uninstall_skills
+
+        try:
+            install_dir = resolve_install_dir(project=project)
+            result = uninstall_skills(install_dir=install_dir)
+        except SkillsInstallLocationError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_bad_input, prefix="Skills uninstall failed")
+        except Exception as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills uninstall failed")
+
+        if output_json:
+            print(json.dumps(result, indent=2))
+            return
+
+        if result["count"] == 0:
+            console.print("[yellow]No managed skills found to uninstall[/yellow]")
+            console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+            return
+
+        console.print("[bold green]Skills uninstalled[/bold green]")
+        console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+        console.print(f"Removed ({result['count']}): [cyan]{', '.join(result['removed_skills'])}[/cyan]")
+
+    @skills.command(name="reinstall")
+    @click.option(
+        "--project",
+        is_flag=True,
+        help="Reinstall in .agents/skills in detected project root (default is global install).",
+    )
+    @click.option(
+        "--skill",
+        "skill_names",
+        multiple=True,
+        help="Skill name to reinstall (repeatable). Defaults to all. Skills not listed will be removed.",
+    )
+    @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
+    def skills_reinstall(project: bool, skill_names: tuple[str, ...], output_json: bool) -> None:
+        """Reinstall Parallel skills (uninstall managed set then install fresh).
+
+        When --skill is provided, the managed install set is replaced with exactly
+        the listed skills.
+        """
+        from parallel_web_tools.core.skills import (
+            SkillsError,
+            SkillsInputError,
+            SkillsInstallLocationError,
+            get_skills_repo_ref,
+            reinstall_skills,
+            resolve_install_dir,
+        )
+
+        try:
+            install_dir = resolve_install_dir(project=project)
+            result = reinstall_skills(
+                install_dir=install_dir,
+                selected_skills=list(skill_names) or None,
+                ref=get_skills_repo_ref(),
+            )
+        except SkillsInstallLocationError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_bad_input, prefix="Skills reinstall failed")
+        except SkillsInputError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_bad_input, prefix="Skills reinstall failed")
+        except SkillsError as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills reinstall failed")
+        except Exception as e:
+            handle_error(e, output_json=output_json, exit_code=exit_api_error, prefix="Skills reinstall failed")
+
+        if output_json:
+            print(json.dumps(result, indent=2))
+            return
+
+        console.print("[bold green]Skills reinstalled[/bold green]")
+        console.print(f"Location: [cyan]{result['install_dir']}[/cyan]")
+        console.print(f"Ref: [cyan]{result['ref']}[/cyan]")
+        console.print(f"Removed ({result['removed_count']}): [cyan]{', '.join(result['removed_skills'])}[/cyan]")
+        console.print(f"Installed ({result['installed_count']}): [cyan]{', '.join(result['installed_skills'])}[/cyan]")
+
+    return skills

--- a/parallel_web_tools/core/__init__.py
+++ b/parallel_web_tools/core/__init__.py
@@ -1,5 +1,6 @@
 """Core functionality for Parallel Data."""
 
+from parallel_web_tools.core import skills
 from parallel_web_tools.core.auth import (
     DeviceCodeInfo,
     create_client,
@@ -81,6 +82,7 @@ from parallel_web_tools.core.user_agent import (
 )
 
 __all__ = [
+    "skills",
     # Auth
     "DeviceCodeInfo",
     "create_client",

--- a/parallel_web_tools/core/__init__.py
+++ b/parallel_web_tools/core/__init__.py
@@ -1,6 +1,5 @@
 """Core functionality for Parallel Data."""
 
-from parallel_web_tools.core import skills
 from parallel_web_tools.core.auth import (
     DeviceCodeInfo,
     create_client,
@@ -82,7 +81,6 @@ from parallel_web_tools.core.user_agent import (
 )
 
 __all__ = [
-    "skills",
     # Auth
     "DeviceCodeInfo",
     "create_client",

--- a/parallel_web_tools/core/skills.py
+++ b/parallel_web_tools/core/skills.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-import base64
+import io
 import json
 import os
 import shutil
+import tempfile
 import time
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import quote
 
@@ -34,6 +38,10 @@ class SkillsInstallLocationError(SkillsError):
 
 class SkillsDownloadError(SkillsError):
     """Raised when remote skills metadata or files cannot be fetched."""
+
+
+class SkillsInputError(SkillsError):
+    """Raised when caller-provided skill arguments are invalid."""
 
 
 def get_skills_repo_ref() -> str:
@@ -76,23 +84,13 @@ def resolve_install_dir(project: bool, start: Path | None = None) -> Path:
     return root / ".agents" / "skills"
 
 
-def _github_contents_url(path: str, ref: str) -> str:
-    encoded_path = quote(path, safe="/")
+def _github_archive_url(ref: str) -> str:
     encoded_ref = quote(ref, safe="")
-    return (
-        f"https://api.github.com/repos/{SKILLS_REPO_OWNER}/{SKILLS_REPO_NAME}/contents/{encoded_path}?ref={encoded_ref}"
-    )
-
-
-def _read_json_response(response: httpx.Response) -> dict | list:
-    try:
-        return response.json()
-    except Exception as e:
-        raise SkillsDownloadError("Failed to decode GitHub response as JSON") from e
+    return f"https://api.github.com/repos/{SKILLS_REPO_OWNER}/{SKILLS_REPO_NAME}/zipball/{encoded_ref}"
 
 
 def _github_headers() -> dict[str, str]:
-    """Build GitHub API headers, using GH_TOKEN when available."""
+    """Build GitHub API headers for skills archive downloads."""
     headers = {
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
@@ -103,80 +101,91 @@ def _github_headers() -> dict[str, str]:
     return headers
 
 
-def _get_contents(client: httpx.Client, path: str, ref: str) -> list[dict]:
-    url = _github_contents_url(path, ref)
-    response = client.get(url)
+def _download_repo_archive(client: httpx.Client, ref: str) -> bytes:
+    # TODO: add retry/backoff for transient GitHub API failures (429/5xx).
+    response = client.get(_github_archive_url(ref))
     if response.status_code >= 400:
         raise SkillsDownloadError(
-            f"Failed to fetch GitHub contents for {path} at ref '{ref}' in "
+            f"Failed to download skills archive at ref '{ref}' from "
             f"{SKILLS_REPO_OWNER}/{SKILLS_REPO_NAME}: HTTP {response.status_code}"
         )
-    payload = _read_json_response(response)
-    if isinstance(payload, dict):
-        return [payload]
-    if isinstance(payload, list):
-        return [item for item in payload if isinstance(item, dict)]
-    raise SkillsDownloadError(f"Unexpected GitHub payload for {path}")
+    return response.content
+
+
+def _extract_repo_archive(archive_bytes: bytes, dest_dir: Path) -> Path:
+    """Extract a GitHub zipball into dest_dir and return the archive root."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as zf:
+            root_name: str | None = None
+
+            for member in zf.infolist():
+                member_path = Path(member.filename)
+                parts = member_path.parts
+                if not parts:
+                    continue
+                if parts[0] in ("", "/"):
+                    raise SkillsDownloadError("Invalid archive entry path")
+                if any(part == ".." for part in parts):
+                    raise SkillsDownloadError("Archive contains unsafe path traversal entry")
+                if root_name is None:
+                    root_name = parts[0]
+
+                target = dest_dir / member_path
+                target_resolved = target.resolve()
+                dest_resolved = dest_dir.resolve()
+                if dest_resolved not in (target_resolved, *target_resolved.parents):
+                    raise SkillsDownloadError("Archive extraction would escape destination directory")
+
+                if member.is_dir():
+                    target.mkdir(parents=True, exist_ok=True)
+                    continue
+
+                target.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(member) as src, target.open("wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    except zipfile.BadZipFile as e:
+        raise SkillsDownloadError("Failed to read downloaded skills archive") from e
+
+    if not root_name:
+        raise SkillsDownloadError("Downloaded skills archive was empty")
+
+    root = dest_dir / root_name
+    if not root.exists() or not root.is_dir():
+        raise SkillsDownloadError("Downloaded skills archive had no repository root directory")
+    return root
+
+
+@contextmanager
+def _downloaded_repo_root(ref: str) -> Iterator[Path]:
+    with httpx.Client(timeout=30, follow_redirects=True, headers=_github_headers()) as client:
+        archive_bytes = _download_repo_archive(client, ref)
+
+    with tempfile.TemporaryDirectory(prefix="parallel-skills-") as tmpdir:
+        repo_root = _extract_repo_archive(archive_bytes, Path(tmpdir))
+        yield repo_root
+
+
+def _skills_root(repo_root: Path) -> Path:
+    skills_root = repo_root / SKILLS_REPO_SKILLS_PATH
+    if not skills_root.exists() or not skills_root.is_dir():
+        raise SkillsDownloadError(
+            f"Downloaded repository does not contain a '{SKILLS_REPO_SKILLS_PATH}/' directory at the requested ref"
+        )
+    return skills_root
+
+
+def _list_skills_from_repo_root(repo_root: Path) -> list[str]:
+    skills_root = _skills_root(repo_root)
+    return sorted(path.name for path in skills_root.iterdir() if path.is_dir())
 
 
 def list_remote_skills(ref: str | None = None) -> list[str]:
     """Return available skill directory names from the remote repository."""
     resolved_ref = ref or get_skills_repo_ref()
-    with httpx.Client(timeout=30, follow_redirects=True, headers=_github_headers()) as client:
-        skills = _list_remote_skills_with_client(client, resolved_ref)
-    return skills
-
-
-def _list_remote_skills_with_client(client: httpx.Client, ref: str) -> list[str]:
-    entries = _get_contents(client, SKILLS_REPO_SKILLS_PATH, ref)
-    skills = [item["name"] for item in entries if item.get("type") == "dir" and isinstance(item.get("name"), str)]
-    return sorted(skills)
-
-
-def _download_dir(client: httpx.Client, remote_path: str, dest: Path, ref: str) -> None:
-    dest.mkdir(parents=True, exist_ok=True)
-    entries = _get_contents(client, remote_path, ref)
-
-    for item in entries:
-        item_type = item.get("type")
-        item_name = item.get("name")
-        item_path = item.get("path")
-        if not isinstance(item_name, str) or not isinstance(item_path, str):
-            continue
-
-        local_path = dest / item_name
-
-        if item_type == "dir":
-            _download_dir(client, item_path, local_path, ref)
-            continue
-
-        if item_type != "file":
-            continue
-
-        file_url = item.get("url")
-        if not isinstance(file_url, str) or not file_url:
-            raise SkillsDownloadError(f"Missing contents URL for {item_path}")
-
-        file_resp = client.get(file_url)
-        if file_resp.status_code >= 400:
-            raise SkillsDownloadError(f"Failed to download {item_path}: HTTP {file_resp.status_code}")
-
-        file_payload = _read_json_response(file_resp)
-        if not isinstance(file_payload, dict):
-            raise SkillsDownloadError(f"Unexpected payload while downloading {item_path}")
-
-        encoding = file_payload.get("encoding")
-        content = file_payload.get("content")
-        if encoding != "base64" or not isinstance(content, str):
-            raise SkillsDownloadError(f"Missing base64 content for {item_path}")
-
-        try:
-            file_bytes = base64.b64decode(content.replace("\n", ""))
-        except Exception as e:
-            raise SkillsDownloadError(f"Failed to decode file content for {item_path}") from e
-
-        local_path.parent.mkdir(parents=True, exist_ok=True)
-        local_path.write_bytes(file_bytes)
+    with _downloaded_repo_root(resolved_ref) as repo_root:
+        return _list_skills_from_repo_root(repo_root)
 
 
 def _manifest_path(install_dir: Path) -> Path:
@@ -212,24 +221,42 @@ def install_skills(
     selected_skills: list[str] | None = None,
     ref: str | None = None,
 ) -> dict:
-    """Install selected (or all) skills into install_dir."""
+    """Install selected (or all) skills into install_dir.
+
+    Only skills previously managed by parallel-cli are reconciled. Unmanaged skill
+    directories are left untouched.
+    """
     resolved_ref = ref or get_skills_repo_ref()
 
-    with httpx.Client(timeout=30, follow_redirects=True, headers=_github_headers()) as client:
-        available = _list_remote_skills_with_client(client, resolved_ref)
+    with _downloaded_repo_root(resolved_ref) as repo_root:
+        skills_root = _skills_root(repo_root)
+        available = _list_skills_from_repo_root(repo_root)
         requested = sorted(set(selected_skills or available))
-        missing = sorted([name for name in requested if name not in available])
+        missing = sorted(name for name in requested if name not in available)
         if missing:
-            raise SkillsError(
+            raise SkillsInputError(
                 f"Unknown skills requested: {', '.join(missing)}. Available skills: {', '.join(available)}"
             )
 
+        manifest = _read_manifest(install_dir)
+        managed_raw = manifest.get("installed_skills")
+        previously_managed: list[str] = (
+            [name for name in managed_raw if isinstance(name, str)] if isinstance(managed_raw, list) else []
+        )
+
         install_dir.mkdir(parents=True, exist_ok=True)
+
+        for skill_name in previously_managed:
+            if skill_name not in requested:
+                skill_dir = install_dir / skill_name
+                if skill_dir.exists() and skill_dir.is_dir():
+                    shutil.rmtree(skill_dir)
+
         for skill_name in requested:
             skill_dir = install_dir / skill_name
             if skill_dir.exists():
                 shutil.rmtree(skill_dir)
-            _download_dir(client, f"{SKILLS_REPO_SKILLS_PATH}/{skill_name}", skill_dir, resolved_ref)
+            shutil.copytree(skills_root / skill_name, skill_dir)
 
     _write_manifest(install_dir, resolved_ref, requested)
     return {

--- a/parallel_web_tools/core/skills.py
+++ b/parallel_web_tools/core/skills.py
@@ -1,0 +1,284 @@
+"""Skill installation helpers for parallel-cli."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+from urllib.parse import quote
+
+import httpx
+
+SKILLS_REPO_OWNER = "parallel-web"
+SKILLS_REPO_NAME = "parallel-agent-skills"
+SKILLS_REPO_SKILLS_PATH = "skills"
+DEFAULT_SKILLS_REPO_REF = "main"
+SKILLS_REPO_REF_ENV = "PARALLEL_SKILLS_REPO_REF"
+GITHUB_TOKEN_ENV = "GH_TOKEN"
+GLOBAL_SKILLS_DIR_ENV = "PARALLEL_SKILLS_GLOBAL_DIR"
+
+PROJECT_ROOT_MARKERS = (".git", "pyproject.toml", "package.json")
+MANIFEST_FILE_NAME = ".parallel-cli-skills-manifest.json"
+
+
+class SkillsError(Exception):
+    """Base error for skills operations."""
+
+
+class SkillsInstallLocationError(SkillsError):
+    """Raised when a project-local install directory cannot be determined."""
+
+
+class SkillsDownloadError(SkillsError):
+    """Raised when remote skills metadata or files cannot be fetched."""
+
+
+def get_skills_repo_ref() -> str:
+    """Return repository ref used for skill downloads."""
+    configured = os.environ.get(SKILLS_REPO_REF_ENV)
+    if configured and configured.strip():
+        return configured.strip()
+    return DEFAULT_SKILLS_REPO_REF
+
+
+def get_global_skills_dir() -> Path:
+    """Return the global skills directory path."""
+    configured = os.environ.get(GLOBAL_SKILLS_DIR_ENV)
+    if configured:
+        return Path(configured).expanduser()
+    return Path.home() / ".agents" / "skills"
+
+
+def find_project_root(start: Path | None = None) -> Path | None:
+    """Find a project root by walking upward for known root markers."""
+    cursor = (start or Path.cwd()).resolve()
+    for candidate in (cursor, *cursor.parents):
+        for marker in PROJECT_ROOT_MARKERS:
+            if (candidate / marker).exists():
+                return candidate
+    return None
+
+
+def resolve_install_dir(project: bool, start: Path | None = None) -> Path:
+    """Resolve install directory for global or project-local skills."""
+    if not project:
+        return get_global_skills_dir()
+
+    root = find_project_root(start=start)
+    if root is None:
+        raise SkillsInstallLocationError(
+            "Could not determine project root from current directory. "
+            "Run this inside a project containing one of: .git, pyproject.toml, package.json."
+        )
+    return root / ".agents" / "skills"
+
+
+def _github_contents_url(path: str, ref: str) -> str:
+    encoded_path = quote(path, safe="/")
+    encoded_ref = quote(ref, safe="")
+    return (
+        f"https://api.github.com/repos/{SKILLS_REPO_OWNER}/{SKILLS_REPO_NAME}/contents/{encoded_path}?ref={encoded_ref}"
+    )
+
+
+def _read_json_response(response: httpx.Response) -> dict | list:
+    try:
+        return response.json()
+    except Exception as e:
+        raise SkillsDownloadError("Failed to decode GitHub response as JSON") from e
+
+
+def _github_headers() -> dict[str, str]:
+    """Build GitHub API headers, using GH_TOKEN when available."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get(GITHUB_TOKEN_ENV)
+    if token and token.strip():
+        headers["Authorization"] = f"Bearer {token.strip()}"
+    return headers
+
+
+def _get_contents(client: httpx.Client, path: str, ref: str) -> list[dict]:
+    url = _github_contents_url(path, ref)
+    response = client.get(url)
+    if response.status_code >= 400:
+        raise SkillsDownloadError(
+            f"Failed to fetch GitHub contents for {path} at ref '{ref}' in "
+            f"{SKILLS_REPO_OWNER}/{SKILLS_REPO_NAME}: HTTP {response.status_code}"
+        )
+    payload = _read_json_response(response)
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    raise SkillsDownloadError(f"Unexpected GitHub payload for {path}")
+
+
+def list_remote_skills(ref: str | None = None) -> list[str]:
+    """Return available skill directory names from the remote repository."""
+    resolved_ref = ref or get_skills_repo_ref()
+    with httpx.Client(timeout=30, follow_redirects=True, headers=_github_headers()) as client:
+        skills = _list_remote_skills_with_client(client, resolved_ref)
+    return skills
+
+
+def _list_remote_skills_with_client(client: httpx.Client, ref: str) -> list[str]:
+    entries = _get_contents(client, SKILLS_REPO_SKILLS_PATH, ref)
+    skills = [item["name"] for item in entries if item.get("type") == "dir" and isinstance(item.get("name"), str)]
+    return sorted(skills)
+
+
+def _download_dir(client: httpx.Client, remote_path: str, dest: Path, ref: str) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    entries = _get_contents(client, remote_path, ref)
+
+    for item in entries:
+        item_type = item.get("type")
+        item_name = item.get("name")
+        item_path = item.get("path")
+        if not isinstance(item_name, str) or not isinstance(item_path, str):
+            continue
+
+        local_path = dest / item_name
+
+        if item_type == "dir":
+            _download_dir(client, item_path, local_path, ref)
+            continue
+
+        if item_type != "file":
+            continue
+
+        file_url = item.get("url")
+        if not isinstance(file_url, str) or not file_url:
+            raise SkillsDownloadError(f"Missing contents URL for {item_path}")
+
+        file_resp = client.get(file_url)
+        if file_resp.status_code >= 400:
+            raise SkillsDownloadError(f"Failed to download {item_path}: HTTP {file_resp.status_code}")
+
+        file_payload = _read_json_response(file_resp)
+        if not isinstance(file_payload, dict):
+            raise SkillsDownloadError(f"Unexpected payload while downloading {item_path}")
+
+        encoding = file_payload.get("encoding")
+        content = file_payload.get("content")
+        if encoding != "base64" or not isinstance(content, str):
+            raise SkillsDownloadError(f"Missing base64 content for {item_path}")
+
+        try:
+            file_bytes = base64.b64decode(content.replace("\n", ""))
+        except Exception as e:
+            raise SkillsDownloadError(f"Failed to decode file content for {item_path}") from e
+
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_bytes(file_bytes)
+
+
+def _manifest_path(install_dir: Path) -> Path:
+    return install_dir / MANIFEST_FILE_NAME
+
+
+def _write_manifest(install_dir: Path, ref: str, installed_skills: list[str]) -> None:
+    data = {
+        "repo": f"{SKILLS_REPO_OWNER}/{SKILLS_REPO_NAME}",
+        "skills_path": SKILLS_REPO_SKILLS_PATH,
+        "ref": ref,
+        "installed_skills": sorted(installed_skills),
+        "installed_at": int(time.time()),
+        "managed_by": "parallel-cli",
+    }
+    install_dir.mkdir(parents=True, exist_ok=True)
+    _manifest_path(install_dir).write_text(json.dumps(data, indent=2))
+
+
+def _read_manifest(install_dir: Path) -> dict:
+    path = _manifest_path(install_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def install_skills(
+    install_dir: Path,
+    selected_skills: list[str] | None = None,
+    ref: str | None = None,
+) -> dict:
+    """Install selected (or all) skills into install_dir."""
+    resolved_ref = ref or get_skills_repo_ref()
+
+    with httpx.Client(timeout=30, follow_redirects=True, headers=_github_headers()) as client:
+        available = _list_remote_skills_with_client(client, resolved_ref)
+        requested = sorted(set(selected_skills or available))
+        missing = sorted([name for name in requested if name not in available])
+        if missing:
+            raise SkillsError(
+                f"Unknown skills requested: {', '.join(missing)}. Available skills: {', '.join(available)}"
+            )
+
+        install_dir.mkdir(parents=True, exist_ok=True)
+        for skill_name in requested:
+            skill_dir = install_dir / skill_name
+            if skill_dir.exists():
+                shutil.rmtree(skill_dir)
+            _download_dir(client, f"{SKILLS_REPO_SKILLS_PATH}/{skill_name}", skill_dir, resolved_ref)
+
+    _write_manifest(install_dir, resolved_ref, requested)
+    return {
+        "install_dir": str(install_dir),
+        "ref": resolved_ref,
+        "installed_skills": requested,
+        "count": len(requested),
+    }
+
+
+def uninstall_skills(install_dir: Path) -> dict:
+    """Uninstall only manifest-managed skills from install_dir."""
+    manifest = _read_manifest(install_dir)
+    managed_raw = manifest.get("installed_skills")
+    managed: list[str] = (
+        [name for name in managed_raw if isinstance(name, str)] if isinstance(managed_raw, list) else []
+    )
+    removed: list[str] = []
+
+    for skill_name in managed:
+        skill_path = install_dir / skill_name
+        if skill_path.exists() and skill_path.is_dir():
+            shutil.rmtree(skill_path)
+            removed.append(skill_name)
+
+    manifest_path = _manifest_path(install_dir)
+    if manifest_path.exists():
+        manifest_path.unlink()
+
+    return {
+        "install_dir": str(install_dir),
+        "removed_skills": sorted(removed),
+        "count": len(removed),
+    }
+
+
+def reinstall_skills(
+    install_dir: Path,
+    selected_skills: list[str] | None = None,
+    ref: str | None = None,
+) -> dict:
+    """Reinstall skills by uninstalling managed set then installing fresh."""
+    uninstall_result = uninstall_skills(install_dir)
+    install_result = install_skills(install_dir, selected_skills=selected_skills, ref=ref)
+    return {
+        "install_dir": install_result["install_dir"],
+        "ref": install_result["ref"],
+        "removed_skills": uninstall_result["removed_skills"],
+        "installed_skills": install_result["installed_skills"],
+        "removed_count": uninstall_result["count"],
+        "installed_count": install_result["count"],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,5 +163,7 @@ known-first-party = ["parallel_web_tools"]
 [dependency-groups]
 dev = [
     "ipykernel>=7.2.0",
+    "pyinstaller>=6.20.0",
+    "tach>=0.34.1",
     "ty>=0.0.33",
 ]

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -6,11 +6,16 @@ Usage:
     python scripts/build.py          # Build using current environment
     uv run scripts/build.py          # Build using uv (recommended)
 
+Prerequisites:
+    Install build dependencies in your project environment first.
+    Recommended: uv sync --extra dev
+
 This creates a standalone executable in dist/parallel-cli/
 The output is a folder (onedir mode) for fast startup times.
 """
 
 import hashlib
+import importlib.util
 import json
 import platform
 import shutil
@@ -19,33 +24,32 @@ import sys
 from pathlib import Path
 
 
-def has_uv() -> bool:
-    """Check if uv is available."""
-    try:
-        subprocess.run(["uv", "--version"], capture_output=True, check=True)
-        return True
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-
-
 def ensure_dependencies():
-    """Ensure build dependencies are installed."""
-    project_root = Path(__file__).parent.parent
+    """Validate build dependencies are already available in the active environment."""
+    missing: list[str] = []
 
-    if has_uv():
-        print("Using uv to install dependencies...")
-        subprocess.run(
-            ["uv", "pip", "install", "-e", ".[cli]", "pyinstaller>=6.0.0"],
-            cwd=project_root,
-            check=True,
-        )
-    else:
-        print("Using pip to install dependencies...")
-        subprocess.run(
-            [sys.executable, "-m", "pip", "install", "-e", ".[cli]", "pyinstaller>=6.0.0"],
-            cwd=project_root,
-            check=True,
-        )
+    if importlib.util.find_spec("PyInstaller") is None:
+        missing.append("pyinstaller>=6.0.0")
+    if importlib.util.find_spec("certifi") is None:
+        missing.append("certifi")
+
+    if not missing:
+        return
+
+    joined = ", ".join(missing)
+    print(f"Missing build dependencies: {joined}")
+    print()
+    print("Install them into your project environment first, then rerun the build.")
+    print("Recommended:")
+    print("  uv sync --extra dev")
+    print()
+    print("Minimal standalone build setup:")
+    print("  uv sync --extra cli")
+    print('  uv pip install "pyinstaller>=6.0.0"')
+    print()
+    print("Then build with:")
+    print("  uv run python scripts/build.py --skip-deps")
+    sys.exit(1)
 
 
 def get_platform_string() -> str:
@@ -123,7 +127,7 @@ def build(skip_deps: bool = False):
 
     # Ensure dependencies
     if not skip_deps:
-        print("\nInstalling dependencies...")
+        print("\nChecking dependencies...")
         ensure_dependencies()
 
     # Clean previous builds

--- a/tach.toml
+++ b/tach.toml
@@ -1,0 +1,34 @@
+forbid_circular_dependencies = true
+root_module = "ignore"
+interfaces = []
+exclude = ["**/*__pycache__", "**/*egg-info", "**/docs", "**/tests", "**/venv"]
+source_roots = ["."]
+
+[[modules]]
+path = "parallel_web_tools.cli.**"
+depends_on = [
+  "parallel_web_tools.cli.**",
+  "parallel_web_tools.core.**",
+  "parallel_web_tools.integrations.**",
+]
+
+[[modules]]
+path = "parallel_web_tools.core.**"
+depends_on = ["parallel_web_tools.core.**"]
+
+# runner is the one core module allowed to dispatch to processors via lazy imports
+# inside _run_processor(); other core modules must remain processor-agnostic.
+[[modules]]
+path = "parallel_web_tools.core.runner"
+depends_on = ["parallel_web_tools.core.**", "parallel_web_tools.processors.**"]
+
+[[modules]]
+path = "parallel_web_tools.integrations.**"
+depends_on = [
+  "parallel_web_tools.core.**",
+  "parallel_web_tools.integrations.**",
+]
+
+[[modules]]
+path = "parallel_web_tools.processors.**"
+depends_on = ["parallel_web_tools.core.**", "parallel_web_tools.processors.**"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1856,6 +1856,37 @@ class TestEnrichRunJsonOutput:
 
 
 class TestSkillsCommands:
+    def test_skills_help_mentions_github_token_and_replacement_behavior(self, runner):
+        result = runner.invoke(main, ["skills", "--help"])
+
+        assert result.exit_code == 0
+        assert "GH_TOKEN" in result.output
+        assert "GitHub API rate limits" in result.output
+
+        result = runner.invoke(main, ["skills", "install", "--help"])
+
+        assert result.exit_code == 0
+        assert "Skills not" in result.output
+        assert "listed will be removed" in result.output
+
+    def test_skills_list_json(self, runner):
+        with (
+            mock.patch("parallel_web_tools.core.skills.get_skills_repo_ref", return_value="main"),
+            mock.patch(
+                "parallel_web_tools.core.skills.list_remote_skills",
+                return_value=["parallel-web-extract", "parallel-web-search"],
+            ),
+        ):
+            result = runner.invoke(main, ["skills", "list", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload == {
+            "ref": "main",
+            "skills": ["parallel-web-extract", "parallel-web-search"],
+            "count": 2,
+        }
+
     def test_skills_install_global_default(self, runner):
         with (
             mock.patch(
@@ -1913,6 +1944,23 @@ class TestSkillsCommands:
         assert result.exit_code == EXIT_BAD_INPUT
         payload = json.loads(result.output)
         assert payload["error"]["message"] == "no project root"
+
+    def test_skills_install_invalid_skill_is_bad_input(self, runner):
+        from parallel_web_tools.core.skills import SkillsInputError
+
+        with (
+            mock.patch("parallel_web_tools.core.skills.resolve_install_dir", return_value="/tmp/.agents/skills"),
+            mock.patch("parallel_web_tools.core.skills.get_skills_repo_ref", return_value="main"),
+            mock.patch(
+                "parallel_web_tools.core.skills.install_skills",
+                side_effect=SkillsInputError("unknown skill"),
+            ),
+        ):
+            result = runner.invoke(main, ["skills", "install", "--skill", "does-not-exist", "--json"])
+
+        assert result.exit_code == EXIT_BAD_INPUT
+        payload = json.loads(result.output)
+        assert payload["error"]["message"] == "unknown skill"
 
     def test_skills_uninstall_json(self, runner):
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,6 +229,7 @@ class TestMainCLI:
         assert "search" in result.output
         assert "extract" in result.output
         assert "enrich" in result.output
+        assert "skills" in result.output
 
     def test_version(self, runner):
         """Should show version."""
@@ -1852,6 +1853,106 @@ class TestEnrichRunJsonOutput:
         assert isinstance(data, list)
         assert len(data) == 1
         assert data[0]["company"] == "Google"
+
+
+class TestSkillsCommands:
+    def test_skills_install_global_default(self, runner):
+        with (
+            mock.patch(
+                "parallel_web_tools.core.skills.resolve_install_dir", return_value="/tmp/.agents/skills"
+            ) as mock_dir,
+            mock.patch("parallel_web_tools.core.skills.get_skills_repo_ref", return_value="main"),
+            mock.patch(
+                "parallel_web_tools.core.skills.install_skills",
+                return_value={
+                    "install_dir": "/tmp/.agents/skills",
+                    "ref": "main",
+                    "installed_skills": ["parallel-web-search"],
+                    "count": 1,
+                },
+            ) as mock_install,
+        ):
+            result = runner.invoke(main, ["skills", "install", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["count"] == 1
+        mock_dir.assert_called_once_with(project=False)
+        mock_install.assert_called_once()
+
+    def test_skills_install_project_sets_project_flag(self, runner):
+        with (
+            mock.patch(
+                "parallel_web_tools.core.skills.resolve_install_dir", return_value="/repo/.agents/skills"
+            ) as mock_dir,
+            mock.patch("parallel_web_tools.core.skills.get_skills_repo_ref", return_value="test-branch"),
+            mock.patch(
+                "parallel_web_tools.core.skills.install_skills",
+                return_value={
+                    "install_dir": "/repo/.agents/skills",
+                    "ref": "test-branch",
+                    "installed_skills": ["parallel-web-search"],
+                    "count": 1,
+                },
+            ),
+        ):
+            result = runner.invoke(main, ["skills", "install", "--project", "--json"])
+
+        assert result.exit_code == 0
+        mock_dir.assert_called_once_with(project=True)
+
+    def test_skills_install_project_root_not_found(self, runner):
+        from parallel_web_tools.core.skills import SkillsInstallLocationError
+
+        with mock.patch(
+            "parallel_web_tools.core.skills.resolve_install_dir",
+            side_effect=SkillsInstallLocationError("no project root"),
+        ):
+            result = runner.invoke(main, ["skills", "install", "--project", "--json"])
+
+        assert result.exit_code == EXIT_BAD_INPUT
+        payload = json.loads(result.output)
+        assert payload["error"]["message"] == "no project root"
+
+    def test_skills_uninstall_json(self, runner):
+        with (
+            mock.patch("parallel_web_tools.core.skills.resolve_install_dir", return_value="/tmp/.agents/skills"),
+            mock.patch(
+                "parallel_web_tools.core.skills.uninstall_skills",
+                return_value={
+                    "install_dir": "/tmp/.agents/skills",
+                    "removed_skills": ["parallel-web-search"],
+                    "count": 1,
+                },
+            ),
+        ):
+            result = runner.invoke(main, ["skills", "uninstall", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["removed_skills"] == ["parallel-web-search"]
+
+    def test_skills_reinstall_json(self, runner):
+        with (
+            mock.patch("parallel_web_tools.core.skills.resolve_install_dir", return_value="/tmp/.agents/skills"),
+            mock.patch("parallel_web_tools.core.skills.get_skills_repo_ref", return_value="main"),
+            mock.patch(
+                "parallel_web_tools.core.skills.reinstall_skills",
+                return_value={
+                    "install_dir": "/tmp/.agents/skills",
+                    "ref": "main",
+                    "removed_skills": ["parallel-web-search"],
+                    "installed_skills": ["parallel-web-extract"],
+                    "removed_count": 1,
+                    "installed_count": 1,
+                },
+            ),
+        ):
+            result = runner.invoke(main, ["skills", "reinstall", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["installed_skills"] == ["parallel-web-extract"]
 
 
 class TestCompletion:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,85 @@
+"""Tests for skills helper module."""
+
+import json
+
+import pytest
+
+from parallel_web_tools.core import skills
+
+
+class TestRepoRef:
+    def test_uses_default_ref(self, monkeypatch):
+        monkeypatch.delenv(skills.SKILLS_REPO_REF_ENV, raising=False)
+        assert skills.get_skills_repo_ref() == skills.DEFAULT_SKILLS_REPO_REF
+
+    def test_uses_env_ref_override(self, monkeypatch):
+        monkeypatch.setenv(skills.SKILLS_REPO_REF_ENV, "feature/test-branch")
+        assert skills.get_skills_repo_ref() == "feature/test-branch"
+
+    def test_ignores_blank_env_ref(self, monkeypatch):
+        monkeypatch.setenv(skills.SKILLS_REPO_REF_ENV, "   ")
+        assert skills.get_skills_repo_ref() == skills.DEFAULT_SKILLS_REPO_REF
+
+
+class TestGithubHeaders:
+    def test_uses_gh_token_when_present(self, monkeypatch):
+        monkeypatch.setenv(skills.GITHUB_TOKEN_ENV, "ghp_test123")
+        headers = skills._github_headers()
+        assert headers["Authorization"] == "Bearer ghp_test123"
+
+    def test_omits_auth_header_when_token_missing(self, monkeypatch):
+        monkeypatch.delenv(skills.GITHUB_TOKEN_ENV, raising=False)
+        headers = skills._github_headers()
+        assert "Authorization" not in headers
+
+
+class TestResolveInstallDir:
+    def test_global_uses_home_agents_skills(self, monkeypatch, tmp_path):
+        monkeypatch.delenv(skills.GLOBAL_SKILLS_DIR_ENV, raising=False)
+        monkeypatch.setattr("parallel_web_tools.core.skills.Path.home", lambda: tmp_path)
+        assert skills.resolve_install_dir(project=False) == tmp_path / ".agents" / "skills"
+
+    def test_global_uses_env_override(self, monkeypatch):
+        monkeypatch.setenv(skills.GLOBAL_SKILLS_DIR_ENV, "~/custom-skills")
+        expected = skills.Path("~/custom-skills").expanduser()
+        assert skills.resolve_install_dir(project=False) == expected
+
+    def test_project_uses_detected_root(self, tmp_path):
+        project_root = tmp_path / "repo"
+        nested = project_root / "src" / "module"
+        nested.mkdir(parents=True)
+        (project_root / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+        assert skills.resolve_install_dir(project=True, start=nested) == project_root / ".agents" / "skills"
+
+    def test_project_fails_without_root_markers(self, tmp_path):
+        start = tmp_path / "no-root" / "subdir"
+        start.mkdir(parents=True)
+
+        with pytest.raises(skills.SkillsInstallLocationError):
+            skills.resolve_install_dir(project=True, start=start)
+
+
+class TestUninstall:
+    def test_uninstall_only_removes_manifest_managed_skills(self, tmp_path):
+        install_dir = tmp_path / ".agents" / "skills"
+        managed = install_dir / "parallel-web-search"
+        unmanaged = install_dir / "custom-skill"
+        managed.mkdir(parents=True)
+        unmanaged.mkdir(parents=True)
+        (managed / "SKILL.md").write_text("managed")
+        (unmanaged / "SKILL.md").write_text("custom")
+
+        manifest = {
+            "installed_skills": ["parallel-web-search"],
+            "ref": "main",
+        }
+        (install_dir / skills.MANIFEST_FILE_NAME).write_text(json.dumps(manifest))
+
+        result = skills.uninstall_skills(install_dir)
+
+        assert result["count"] == 1
+        assert result["removed_skills"] == ["parallel-web-search"]
+        assert not managed.exists()
+        assert unmanaged.exists()
+        assert not (install_dir / skills.MANIFEST_FILE_NAME).exists()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,10 +1,13 @@
 """Tests for skills helper module."""
 
+import io
 import json
+import zipfile
+from contextlib import contextmanager
 
 import pytest
 
-from parallel_web_tools.core import skills
+import parallel_web_tools.core.skills as skills
 
 
 class TestRepoRef:
@@ -22,15 +25,17 @@ class TestRepoRef:
 
 
 class TestGithubHeaders:
+    def test_uses_expected_github_headers(self, monkeypatch):
+        monkeypatch.delenv(skills.GITHUB_TOKEN_ENV, raising=False)
+        headers = skills._github_headers()
+        assert headers["Accept"] == "application/vnd.github+json"
+        assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+        assert "Authorization" not in headers
+
     def test_uses_gh_token_when_present(self, monkeypatch):
         monkeypatch.setenv(skills.GITHUB_TOKEN_ENV, "ghp_test123")
         headers = skills._github_headers()
         assert headers["Authorization"] == "Bearer ghp_test123"
-
-    def test_omits_auth_header_when_token_missing(self, monkeypatch):
-        monkeypatch.delenv(skills.GITHUB_TOKEN_ENV, raising=False)
-        headers = skills._github_headers()
-        assert "Authorization" not in headers
 
 
 class TestResolveInstallDir:
@@ -58,6 +63,82 @@ class TestResolveInstallDir:
 
         with pytest.raises(skills.SkillsInstallLocationError):
             skills.resolve_install_dir(project=True, start=start)
+
+
+def _make_repo_zip() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr("parallel-web-parallel-agent-skills-abc123/skills/parallel-web-search/SKILL.md", "search")
+        zf.writestr("parallel-web-parallel-agent-skills-abc123/skills/parallel-web-extract/SKILL.md", "extract")
+    return buffer.getvalue()
+
+
+class TestArchiveInstall:
+    def test_extract_repo_archive_returns_repo_root(self, tmp_path):
+        repo_root = skills._extract_repo_archive(_make_repo_zip(), tmp_path)
+        assert repo_root.name == "parallel-web-parallel-agent-skills-abc123"
+        assert (repo_root / "skills" / "parallel-web-search" / "SKILL.md").read_text() == "search"
+
+    def test_list_remote_skills_from_archive(self, monkeypatch, tmp_path):
+        repo_root = skills._extract_repo_archive(_make_repo_zip(), tmp_path)
+
+        @contextmanager
+        def fake_downloaded_repo_root(ref: str):
+            assert ref == "feature/test-branch"
+            yield repo_root
+
+        monkeypatch.setattr(skills, "_downloaded_repo_root", fake_downloaded_repo_root)
+        assert skills.list_remote_skills("feature/test-branch") == ["parallel-web-extract", "parallel-web-search"]
+
+    def test_install_skills_from_archive(self, monkeypatch, tmp_path):
+        repo_root = skills._extract_repo_archive(_make_repo_zip(), tmp_path / "archive")
+        install_dir = tmp_path / "install"
+
+        @contextmanager
+        def fake_downloaded_repo_root(ref: str):
+            assert ref == "main"
+            yield repo_root
+
+        monkeypatch.setattr(skills, "_downloaded_repo_root", fake_downloaded_repo_root)
+
+        result = skills.install_skills(install_dir, selected_skills=["parallel-web-search"], ref="main")
+
+        assert result["installed_skills"] == ["parallel-web-search"]
+        assert (install_dir / "parallel-web-search" / "SKILL.md").read_text() == "search"
+        assert not (install_dir / "parallel-web-extract").exists()
+
+    def test_install_subset_removes_previously_managed_skills(self, monkeypatch, tmp_path):
+        repo_root = skills._extract_repo_archive(_make_repo_zip(), tmp_path / "archive")
+        install_dir = tmp_path / "install"
+
+        @contextmanager
+        def fake_downloaded_repo_root(ref: str):
+            yield repo_root
+
+        monkeypatch.setattr(skills, "_downloaded_repo_root", fake_downloaded_repo_root)
+
+        skills.install_skills(install_dir, ref="main")
+        skills.install_skills(install_dir, selected_skills=["parallel-web-search"], ref="main")
+
+        assert (install_dir / "parallel-web-search").exists()
+        assert not (install_dir / "parallel-web-extract").exists()
+
+        result = skills.uninstall_skills(install_dir)
+
+        assert result["removed_skills"] == ["parallel-web-search"]
+        assert not any(path.name.startswith("parallel-web-") for path in install_dir.iterdir())
+
+    def test_install_skills_rejects_unknown_names(self, monkeypatch, tmp_path):
+        repo_root = skills._extract_repo_archive(_make_repo_zip(), tmp_path / "archive")
+
+        @contextmanager
+        def fake_downloaded_repo_root(ref: str):
+            yield repo_root
+
+        monkeypatch.setattr(skills, "_downloaded_repo_root", fake_downloaded_repo_root)
+
+        with pytest.raises(skills.SkillsInputError, match="Unknown skills requested"):
+            skills.install_skills(tmp_path / "install", selected_skills=["does-not-exist"], ref="main")
 
 
 class TestUninstall:

--- a/uv.lock
+++ b/uv.lock
@@ -638,6 +638,30 @@ wheels = [
 ]
 
 [[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/63/210aaa302d6a0a78daa67c5c15bbac2cad361722841278b0209b6da20855/gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1", size = 219367, upload-time = "2026-04-29T00:31:20.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/6f/b842bfa6f21d6f87c57f9abf7194225e55279d96d869775e19e9f7236fc5/gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c", size = 212190, upload-time = "2026-04-29T00:31:18.412Z" },
+]
+
+[[package]]
 name = "google-api-core"
 version = "2.30.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1151,6 +1175,33 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version == '3.12.*'",
+    "python_full_version == '3.11.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1476,6 +1527,8 @@ spark = [
 [package.dev-dependencies]
 dev = [
     { name = "ipykernel" },
+    { name = "pyinstaller" },
+    { name = "tach" },
     { name = "ty" },
 ]
 
@@ -1514,6 +1567,8 @@ provides-extras = ["cli", "polars", "pandas", "duckdb", "snowflake", "bigquery",
 [package.metadata.requires-dev]
 dev = [
     { name = "ipykernel", specifier = ">=7.2.0" },
+    { name = "pyinstaller", specifier = ">=6.20.0" },
+    { name = "tach", specifier = ">=0.34.1" },
     { name = "ty", specifier = ">=0.0.33" },
 ]
 
@@ -1922,6 +1977,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pydot"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1994,6 +2061,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/a8/26d36401e3ab8eed9030ad33f381da7856fcfad5691780fccd1b019718fc/pyopenssl-26.1.0.tar.gz", hash = "sha256:737f0a2275c5bc54f3b02137687e1a765931fb3949b9a92a825e4d33b9eec08b", size = 186181, upload-time = "2026-04-24T20:23:48.115Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/41/52f3a3e812b816a91e89aa504199d8bf989a1f873192b10762be66cf2009/pyopenssl-26.1.0-py3-none-any.whl", hash = "sha256:115563879b2c8ccb207975705d3e491434d8c9d7c79667c902ecbf5f3bbd2ece", size = 58109, upload-time = "2026-04-24T20:23:46.273Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -2322,6 +2398,15 @@ wheels = [
 ]
 
 [[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2477,6 +2562,42 @@ wheels = [
 ]
 
 [[package]]
+name = "tach"
+version = "0.34.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitpython" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "prompt-toolkit" },
+    { name = "pydot" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "tomli" },
+    { name = "tomli-w" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/5b/a82de1482ede35e245951a6e039d608cdc86111aa8207344fffb8c927623/tach-0.34.1.tar.gz", hash = "sha256:58b5a8f9dd4f5c9fc9b1ade875aa0b31d3ac2f2f6802c655c05197a503d5acde", size = 765955, upload-time = "2026-04-03T06:12:28.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/3f/d071b841bf634da94068b84d7a2098c99c18deb21b3418969f29e152d793/tach-0.34.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6dff869e7f8933be23055f407a751e6f9e4c8ecb0bf3a93a962a0815e106c313", size = 4100880, upload-time = "2026-04-03T06:12:20.276Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ae/aeb7f67c34b5a9ee43d1aa556b16c6e60424cafeb3f23e6fbf3298a968cd/tach-0.34.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:70d55ec38dfcc15f1fff9e420ba17d63c36bb1b27f92abb8e8c910ffb71fd233", size = 3969195, upload-time = "2026-04-03T06:12:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/de/12e565a0374436ba2b9c00ba68c3a9bf9999081ac546faf33da77162316e/tach-0.34.1-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:862d240a7fc297283a51c857eb269d8c56163f14b7e398f757b284bed1e3df4f", size = 4335854, upload-time = "2026-04-03T06:12:11.065Z" },
+    { url = "https://files.pythonhosted.org/packages/24/f7/3c75beb144017a22229808b497bfb22cd79acc11d836c9870dc8708185a7/tach-0.34.1-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fcb8ca825287160c1dd37b1cb164b88675e01ee97304ce14d50d7e8e1d3b853c", size = 4237244, upload-time = "2026-04-03T06:12:14.931Z" },
+    { url = "https://files.pythonhosted.org/packages/04/90/3459ce8c55a0aa4fa4533faf66cbbfef37eb5927aab1b87f8439c6db228b/tach-0.34.1-cp37-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b272ee726d8b0ef3887d3a3057f618922ab0f7471e1b1d6096f78f2ae93727e4", size = 4648719, upload-time = "2026-04-03T06:12:33.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d3/75b46da7c62a929ddde6c9eb4bb54f775693ee5a006f1b9a069a9aa2f5f2/tach-0.34.1-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6042b4f040c5941d28229963451b94a8cf2b08cdbb0ab0e338a04a46887c712f", size = 5203497, upload-time = "2026-04-03T06:12:21.997Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f7/838d3c2bc0972626eddb3f69d13fdf3eaa7cc46c6132ad965fe7839fe452/tach-0.34.1-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9b52a70262f16b701aaa03781656d808f88a3eb6a263762f8cea726ea9ffb980", size = 4349388, upload-time = "2026-04-03T06:12:26.288Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a0/25ac1fb225aa07faacb29c2470dc49633583fed11214c9e128eae65dece9/tach-0.34.1-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1cba2d957371fde09c64cb1b70349844e33fae3d87f55e6b002929587c5c7826", size = 4593579, upload-time = "2026-04-03T06:12:39.73Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/54/29ffea4faf1c0c623bc2e97e8affc658fbaf38fcf8babf758fa63864dc1b/tach-0.34.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c600ea6f8748ea13183aaf802fb733c148238e252cc0e66a85ac8d6de9939906", size = 4513785, upload-time = "2026-04-03T06:12:13.145Z" },
+    { url = "https://files.pythonhosted.org/packages/66/5e/c716a12ed58a7cc23b27f61f52e31e60410914b2a4afdb0b1a88d16008a7/tach-0.34.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:7be15f69c99b89cdadc2835368fc3cfb3ad45e74c7a704a7d42bcdd2917608b2", size = 4512695, upload-time = "2026-04-03T06:12:16.831Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f6/8538205bba54d77d8b5e3f4afe8203d705bc430578f59bf4d108b3b6da47/tach-0.34.1-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:d917fc81adae85e9b3f2d29e135ba572a69dc677661727012b3adf95e0216e9e", size = 4649718, upload-time = "2026-04-03T06:12:37.908Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/340e9ba6821d4e97f1bfeea5ad36a07c888f3422bb68f4805c74c1dc576c/tach-0.34.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f94909630d699806e8682662962de0ac76ecc05dfcf7893af2c7e1a5c71de57e", size = 5333192, upload-time = "2026-04-03T06:12:24.289Z" },
+    { url = "https://files.pythonhosted.org/packages/04/c2/d0e46185745af3a3d4057fd73eeac9ec003f054d5591c54e2fd835f4cbe4/tach-0.34.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1246b2718cfffecd4e6d66d6e232323fc4b3f2c68b4c990af0063464808f85fa", size = 4641868, upload-time = "2026-04-03T06:12:44.163Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/0209e74d57b0d32057b6ea997b77db847e38d649bd27e6261a4bd58e1da5/tach-0.34.1-cp37-abi3-win32.whl", hash = "sha256:abd9d1e468a9b8bec1e0037c06797b31e9c23c62adf13bcfacf057a21310ad3f", size = 3431420, upload-time = "2026-04-03T06:12:31.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6c/51f1d58eb3ebd1f79d2944f4813806c18c9c715178956424a4528e8bd281/tach-0.34.1-cp37-abi3-win_amd64.whl", hash = "sha256:0220c002da4bf4656b121c6317313490e8660627e5200251e0bca3e00a27d0c4", size = 3737055, upload-time = "2026-04-03T06:12:29.714Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2a/f0c5fbc486d251de9303eaba1a694fc9781d3da7d244cdb403884634a664/tach-0.34.1-pp311-pypy311_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b54972211022eafe29a03f5fd4c34d2a7b52ed77eb0e9ff897d64f4c8c2dcd2f", size = 4641442, upload-time = "2026-04-03T06:12:35.703Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a0/4a1aa15f3efe68e437d5a00c33adc71e1311b74f66def645ded3483f0992/tach-0.34.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c396aef13bd7e5398674886115160f4d6b9cf7baae1fb9431689d9ac4237f97a", size = 4585091, upload-time = "2026-04-03T06:12:41.836Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2528,6 +2649,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This will be useful for agentic onboarding so we can ensure skills are installed regardless of what agent harness someone is using.

Tested locally with `uv run parallel-cli install`