### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -59,14 +59,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PRERELEASE_FLAG=""
+          NOTES_START_FLAG=""
           if [[ "${{ needs.check.outputs.is_prerelease }}" == "true" ]]; then
             PRERELEASE_FLAG="--prerelease"
+          else
+            # Span notes from the previous stable release so changes that
+            # landed in intermediate RCs are included in the stable changelog.
+            PREV_STABLE="$(gh release list --exclude-pre-releases --exclude-drafts --limit 1 --json tagName --jq '.[0].tagName')"
+            if [[ -n "$PREV_STABLE" ]]; then
+              NOTES_START_FLAG="--notes-start-tag $PREV_STABLE"
+            fi
           fi
 
           gh release create "${{ needs.check.outputs.tag }}" \
             --target "${{ github.sha }}" \
             --title "${{ needs.check.outputs.tag }}" \
             --generate-notes \
+            $NOTES_START_FLAG \
             $PRERELEASE_FLAG
 
       - name: Trigger downstream workflows

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-web-cli",
-  "version": "0.3.0-rc.4",
+  "version": "0.3.0",
   "description": "CLI for the Parallel API — web search, data enrichment, and monitoring",
   "homepage": "https://github.com/parallel-web/parallel-web-tools",
   "repository": {

--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -29,7 +29,7 @@ from parallel_web_tools.core import (
     run_tasks,
 )
 
-__version__ = "0.3.0rc4"
+__version__ = "0.3.0"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.3.0rc4
+parallel-web-tools>=0.3.0
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.3.0rc4"
+version = "0.3.0"
 description = "Parallel Tools: CLI and Python SDK for AI-powered web intelligence"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1450,7 +1450,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.3.0rc4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release 0.3.0

Bumps version from 0.3.0rc4 to 0.3.0.

When this PR is merged to main, the release workflow will automatically:
- Create tag `v0.3.0`
- Create a GitHub Release with auto-generated notes
- Build binaries for all platforms
- Publish to PyPI
- Publish to npm