### PR TITLE
chore: bump version to 0.4.0rc2

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-web-cli",
-  "version": "0.4.0-rc.1",
+  "version": "0.4.0-rc.2",
   "description": "CLI for the Parallel API — web search, data enrichment, and monitoring",
   "homepage": "https://github.com/parallel-web/parallel-web-tools",
   "repository": {

--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -35,7 +35,7 @@ from parallel_web_tools.core import (
     update_monitor,
 )
 
-__version__ = "0.4.0rc1"
+__version__ = "0.4.0rc2"
 
 __all__ = [
     # Auth

--- a/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
+++ b/parallel_web_tools/integrations/bigquery/cloud_function/requirements.txt
@@ -1,5 +1,5 @@
 # Cloud Function dependencies for BigQuery Remote Function
 functions-framework>=3.0.0
 flask>=3.0.0
-parallel-web-tools>=0.4.0rc1
+parallel-web-tools>=0.4.0rc2
 google-cloud-secret-manager>=2.20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "parallel-web-tools"
-version = "0.4.0rc1"
+version = "0.4.0rc2"
 description = "Parallel Tools: CLI and Python SDK for AI-powered web intelligence"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web-tools"
-version = "0.4.0rc1"
+version = "0.4.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Release 0.4.0rc2 (pre-release)

Bumps version from 0.4.0rc1 to 0.4.0rc2.

When this PR is merged to main, the release workflow will automatically:
- Create tag `v0.4.0rc2`
- Create a GitHub Release with auto-generated notes
- Build binaries for all platforms
- Publish to PyPI
- Publish to npm