### PR TITLE
Updating CI release flow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,8 +22,9 @@ jobs:
     steps:
       - name: Check if this is a version bump commit
         id: check
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           if [[ "$COMMIT_MSG" =~ ^chore:\ bump\ version\ to\ ([0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?) ]]; then
             VERSION="${BASH_REMATCH[1]}"
             echo "should_release=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Move `head_commit.message` into the step's `env:` block instead of interpolating it into the `run:` script in the auto-release workflow's version-bump detection step.

## Test plan
- [ ] Workflow continues to detect `chore: bump version to X.Y.Z` commits on `main` and sets `should_release`, `version`, `tag`, and `is_prerelease` outputs correctly.
- [ ] RC versions still flagged as prerelease.