### PR TITLE
feat: add entity-search command and bump sdk dep to 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ parallel-cli
 ├── findall                 # Web-scale entity discovery
 │   ├── run                 # Discover entities matching a natural language objective
 │   ├── ingest              # Preview the schema before running
+│   ├── entity-search       # Fast entity search (best-effort optimized for low latency)
 │   ├── status              # Check status of a FindAll run
 │   ├── poll                # Poll until completion
 │   ├── result              # Fetch results of a completed run
@@ -255,6 +256,9 @@ parallel-cli enrich suggest "Find CEO" --json
 # FindAll: discover entities
 parallel-cli findall run "AI startups in healthcare" --json
 
+# FindAll entity-search: fast, low-latency ranked entities (synchronous)
+parallel-cli findall entity-search "AI startups in healthcare" -t companies -n 25
+
 # Monitor: track web changes
 parallel-cli monitor create "Track Tesla SEC filings" --frequency 1d --json
 
@@ -376,6 +380,16 @@ from parallel_web_tools import enrich_findall, extend_findall, get_findall_schem
 schema = get_findall_schema(result.run_id)
 enriched = enrich_findall(result.run_id, ["funding amount", "number of employees"])
 extended = extend_findall(result.run_id, additional_matches=10)
+
+
+# Fast, low-latency entity search (synchronous)
+from parallel_web_tools import entity_search_findall
+
+entities = entity_search_findall(
+    "AI startups in healthcare",
+    entity_type="companies",  # "companies" or "people"
+    match_limit=25,
+)
 ```
 
 ### Monitor

--- a/parallel_web_tools/__init__.py
+++ b/parallel_web_tools/__init__.py
@@ -13,6 +13,7 @@ from parallel_web_tools.core import (
     create_monitor,
     enrich_batch,
     enrich_single,
+    entity_search_findall,
     get_api_key,
     get_async_client,
     get_auth_status,
@@ -66,6 +67,7 @@ __all__ = [
     "run_enrichment_from_dict",
     # FindAll
     "run_findall",
+    "entity_search_findall",
     # Monitor
     "cancel_monitor",
     "create_monitor",

--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -31,6 +31,7 @@ from parallel_web_tools.core import (
     create_monitor,
     create_research_task,
     enrich_findall,
+    entity_search_findall,
     extend_findall,
     get_api_key,
     get_auth_status,
@@ -2751,6 +2752,92 @@ def findall_ingest(objective: str, output_json: bool):
 
             console.print("\n[dim]Use 'parallel-cli findall run' to start a run with this schema[/dim]")
             console.print("[dim]Use --json to get machine-readable output for programmatic use[/dim]")
+
+    except Exception as e:
+        _handle_error(e, output_json=output_json)
+
+
+@findall.command(name="entity-search")
+@click.argument("objective")
+@click.option(
+    "-t",
+    "--entity-type",
+    type=click.Choice(["companies", "people"]),
+    required=True,
+    help="Entity type to search for",
+)
+@click.option(
+    "-n",
+    "--match-limit",
+    type=click.IntRange(5, 1000),
+    default=10,
+    show_default=True,
+    help="Maximum entities to return (5-1000)",
+)
+@click.option("-o", "--output", "output_file", type=click.Path(), help="Save result to JSON file")
+@click.option("--json", "output_json", is_flag=True, help="Output JSON to stdout")
+def findall_entity_search(
+    objective: str,
+    entity_type: str,
+    match_limit: int,
+    output_file: str | None,
+    output_json: bool,
+):
+    """Return ranked entities matching a natural language objective.
+
+    A best-effort, low-latency search. For comprehensive match evaluation and
+    enrichment, use `parallel-cli findall run` instead.
+
+    OBJECTIVE is a natural language description of what to find.
+
+    Examples:
+
+        parallel-cli findall entity-search "AI startups in San Francisco" -t companies
+
+        parallel-cli findall entity-search "Senior PMs at AI startups" -t people -n 25
+
+        parallel-cli findall entity-search "Charlotte roofing companies" -t companies -o out.json
+    """
+    try:
+        result = entity_search_findall(
+            objective,
+            entity_type=entity_type,
+            match_limit=match_limit,
+            source="cli",
+        )
+
+        write_json_output(result, output_file, output_json)
+
+        if not output_json:
+            entities = result.get("entities", []) or []
+
+            console.print("\n[bold green]Entity Search Complete![/bold green]")
+            console.print(f"[dim]Entity set: {result.get('entity_set_id')}[/dim]")
+            console.print(f"[dim]Entity type: {entity_type} | Found: {len(entities)}[/dim]\n")
+
+            if entities:
+                from rich.table import Table
+
+                table = Table(title=f"Entities ({len(entities)})")
+                table.add_column("Name", style="cyan", no_wrap=True)
+                table.add_column("URL", style="dim")
+                table.add_column("Description", max_width=50)
+
+                for c in entities:
+                    table.add_row(
+                        c.get("name", ""),
+                        c.get("url", ""),
+                        (c.get("description", "") or "")[:50],
+                    )
+
+                console.print(table)
+                console.print()
+            else:
+                console.print("[yellow]No entities returned.[/yellow]")
+                console.print("[dim]Tip: check that --entity-type matches the objective (companies vs people).[/dim]\n")
+
+            if not output_file:
+                console.print("[dim]Use --output to save full results, or --json for machine-readable output[/dim]")
 
     except Exception as e:
         _handle_error(e, output_json=output_json)

--- a/parallel_web_tools/core/__init__.py
+++ b/parallel_web_tools/core/__init__.py
@@ -25,10 +25,12 @@ from parallel_web_tools.core.batch import (
     run_tasks,
 )
 from parallel_web_tools.core.findall import (
+    ENTITY_SEARCH_ENTITY_TYPES,
     FINDALL_GENERATORS,
     cancel_findall_run,
     create_findall_run,
     enrich_findall,
+    entity_search_findall,
     extend_findall,
     get_findall_result,
     get_findall_schema,
@@ -138,10 +140,12 @@ __all__ = [
     "poll_research",
     "run_research",
     # FindAll
+    "ENTITY_SEARCH_ENTITY_TYPES",
     "FINDALL_GENERATORS",
     "cancel_findall_run",
     "create_findall_run",
     "enrich_findall",
+    "entity_search_findall",
     "extend_findall",
     "get_findall_result",
     "get_findall_schema",

--- a/parallel_web_tools/core/findall.py
+++ b/parallel_web_tools/core/findall.py
@@ -14,7 +14,7 @@ The typical workflow is:
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal, cast
 
 from parallel_web_tools.core.auth import create_client
 from parallel_web_tools.core.polling import poll_until
@@ -28,6 +28,10 @@ FINDALL_GENERATORS = {
 }
 
 FINDALL_TERMINAL_STATUSES = ("completed", "failed", "cancelled")
+
+# Entity types supported by the sync entity-search endpoint.
+EntitySearchEntityType = Literal["companies", "people"]
+ENTITY_SEARCH_ENTITY_TYPES: tuple[EntitySearchEntityType, ...] = ("companies", "people")
 
 
 def _serialize(obj: Any) -> Any:
@@ -575,6 +579,42 @@ def extend_findall(
     result = client.beta.findall.extend(
         findall_id=findall_id,
         additional_match_limit=additional_match_limit,
+    )
+    return _serialize(result)
+
+
+def entity_search_findall(
+    objective: str,
+    entity_type: str,
+    match_limit: int,
+    api_key: str | None = None,
+    source: ClientSource = "python",
+) -> dict[str, Any]:
+    """Run a synchronous entity search for ranked entities.
+
+    Best-effort, low-latency search that returns ranked entities for a natural
+    language objective. For comprehensive match evaluation and enrichment, use
+    the full FindAll API (run_findall / create_findall_run).
+
+    Args:
+        objective: Natural language description of what to find.
+        entity_type: One of "companies" or "people".
+        match_limit: Maximum entities to return.
+        api_key: Optional API key override.
+        source: Client source identifier for User-Agent.
+
+    Returns:
+        Dict with entity_set_id and a ranked list of entities
+        ({"name", "description", "url"}).
+    """
+    if entity_type not in ENTITY_SEARCH_ENTITY_TYPES:
+        raise ValueError(f"entity_type must be one of {ENTITY_SEARCH_ENTITY_TYPES}, got {entity_type!r}")
+
+    client = create_client(api_key, source)
+    result = client.beta.findall.entity_search(
+        objective=objective,
+        entity_type=cast(EntitySearchEntityType, entity_type),
+        match_limit=match_limit,
     )
     return _serialize(result)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "parallel-web>=0.6.0",
+    "parallel-web>=1.0.0,<2",
     "python-dotenv>=1.0.0",
     # CLI dependencies (minimal - search, extract, enrich with CLI args)
     "click>=8.1.0",

--- a/tests/test_findall.py
+++ b/tests/test_findall.py
@@ -15,6 +15,7 @@ from parallel_web_tools.core.findall import (
     _serialize,
     cancel_findall_run,
     create_findall_run,
+    entity_search_findall,
     get_findall_result,
     get_findall_status,
     ingest_findall,
@@ -229,6 +230,53 @@ class TestIngestFindall:
         ) as mock_create:
             ingest_findall("query", api_key="test-key", source="cli")
             mock_create.assert_called_with("test-key", "cli")
+
+
+class TestEntitySearchFindall:
+    """Tests for entity_search_findall function."""
+
+    def _make_response(self, entities=None, entity_set_id="entity_set_xyz"):
+        response = mock.MagicMock()
+        response.model_dump.return_value = {
+            "entity_set_id": entity_set_id,
+            "entities": entities
+            if entities is not None
+            else [{"name": "Acme", "url": "acme.com", "description": "An AI company"}],
+        }
+        return response
+
+    def test_entity_search_basic(self, mock_parallel_client):
+        mock_parallel_client.beta.findall.entity_search.return_value = self._make_response()
+
+        result = entity_search_findall("Find AI companies", entity_type="companies", match_limit=10)
+
+        assert result["entity_set_id"] == "entity_set_xyz"
+        assert result["entities"][0]["name"] == "Acme"
+        mock_parallel_client.beta.findall.entity_search.assert_called_once_with(
+            objective="Find AI companies",
+            entity_type="companies",
+            match_limit=10,
+        )
+
+    def test_entity_search_with_people_and_limit(self, mock_parallel_client):
+        mock_parallel_client.beta.findall.entity_search.return_value = self._make_response(
+            entities=[{"name": "Jane Doe", "url": "linkedin.com/jane", "description": "PM"}],
+        )
+
+        entity_search_findall(
+            "Senior PMs at AT startups",
+            entity_type="people",
+            match_limit=25,
+        )
+
+        call_kwargs = mock_parallel_client.beta.findall.entity_search.call_args.kwargs
+        assert call_kwargs["entity_type"] == "people"
+        assert call_kwargs["match_limit"] == 25
+
+    def test_entity_search_rejects_unknown_entity_type(self, mock_parallel_client):
+        with pytest.raises(ValueError, match="entity_type"):
+            entity_search_findall("query", entity_type="organizations", match_limit=10)
+        mock_parallel_client.beta.findall.entity_search.assert_not_called()
 
 
 class TestCreateFindallRun:
@@ -807,6 +855,73 @@ class TestFindallIngestCommand:
             assert result.exit_code == 0
             assert "people" in result.output
             # Should not crash on None enrichments
+
+
+class TestFindallEntitySearchCommand:
+    """Tests for the findall entity-search CLI command."""
+
+    def test_entity_search_help(self, runner):
+        result = runner.invoke(main, ["findall", "entity-search", "--help"])
+        assert result.exit_code == 0
+        assert "OBJECTIVE" in result.output
+        assert "entity-type" in result.output
+
+    def test_entity_search_basic(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.entity_search_findall") as mock_es:
+            mock_es.return_value = {
+                "entity_set_id": "entity_set_abc",
+                "entities": [
+                    {"name": "Acme", "url": "acme.com", "description": "An AI company"},
+                ],
+            }
+
+            result = runner.invoke(main, ["findall", "entity-search", "AI companies", "-t", "companies"])
+
+            assert result.exit_code == 0
+            assert "Acme" in result.output
+            mock_es.assert_called_once_with(
+                "AI companies",
+                entity_type="companies",
+                match_limit=10,
+                source="cli",
+            )
+
+    def test_entity_search_requires_entity_type(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.entity_search_findall") as mock_es:
+            result = runner.invoke(main, ["findall", "entity-search", "AI companies"])
+
+            assert result.exit_code != 0
+            assert "entity-type" in result.output
+            mock_es.assert_not_called()
+
+    def test_entity_search_json(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.entity_search_findall") as mock_es:
+            payload = {
+                "entity_set_id": "es_json",
+                "entities": [{"name": "Foo", "url": "foo.com", "description": "x"}],
+            }
+            mock_es.return_value = payload
+
+            result = runner.invoke(main, ["findall", "entity-search", "Find foos", "-t", "companies", "--json"])
+
+            assert result.exit_code == 0
+            assert json.loads(result.output) == payload
+
+    def test_entity_search_rejects_unknown_type(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.entity_search_findall") as mock_es:
+            result = runner.invoke(main, ["findall", "entity-search", "query", "-t", "organizations"])
+
+            assert result.exit_code != 0
+            mock_es.assert_not_called()
+
+    def test_entity_search_rejects_out_of_range_limit(self, runner):
+        with mock.patch("parallel_web_tools.cli.commands.entity_search_findall") as mock_es:
+            below = runner.invoke(main, ["findall", "entity-search", "query", "-t", "companies", "-n", "3"])
+            above = runner.invoke(main, ["findall", "entity-search", "query", "-t", "companies", "-n", "1001"])
+
+            assert below.exit_code != 0
+            assert above.exit_code != 0
+            mock_es.assert_not_called()
 
 
 class TestFindallStatusCommand:

--- a/uv.lock
+++ b/uv.lock
@@ -1657,7 +1657,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web"
-version = "0.6.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1667,9 +1667,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/81/101c961fe6665212df01fb39a70ebb379dc33529c7bc9210675c0f525139/parallel_web-0.6.0.tar.gz", hash = "sha256:f8aecd3f1958090090c4516881cefea4f55c40948ba3bb99217ca9a6d4263225", size = 173149, upload-time = "2026-05-06T19:13:09.782Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ca/78e12e5aa440fc45f66536b8c53941240912516ebd66b814abf229a12a25/parallel_web-1.0.0.tar.gz", hash = "sha256:d672771ed7fd642c5cad5b0d0d48b4fc93275446e5289757a6b1392bc0975448", size = 159658, upload-time = "2026-06-02T18:43:43.237Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/7c/7e8b63a0e90efaf567a818fca86c6ad3a85711f8995d2657b51b0cae2351/parallel_web-0.6.0-py3-none-any.whl", hash = "sha256:dc5342ef7262bd2e9f85eb7eace32833bd3d7e3af0bf5fbd780d1ea8c8d9ceb0", size = 199217, upload-time = "2026-05-06T19:13:08.316Z" },
+    { url = "https://files.pythonhosted.org/packages/66/94/fe4a09f1d8b28526363ccff41fc3a2b3cd716356e6fb296547d717df8671/parallel_web-1.0.0-py3-none-any.whl", hash = "sha256:627e6fea94d72a944b1b382735c169f0aa64abdb7749de1efbdd21a283d467db", size = 170701, upload-time = "2026-06-02T18:43:42.071Z" },
 ]
 
 [[package]]
@@ -1765,7 +1765,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "nest-asyncio", marker = "extra == 'duckdb'", specifier = ">=1.6.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.3.0" },
-    { name = "parallel-web", specifier = ">=0.6.0" },
+    { name = "parallel-web", specifier = ">=1.0.0,<2" },
     { name = "parallel-web-tools", extras = ["all", "spark"], marker = "extra == 'dev'" },
     { name = "parallel-web-tools", extras = ["cli"], marker = "extra == 'bigquery'" },
     { name = "parallel-web-tools", extras = ["cli", "polars"], marker = "extra == 'duckdb'" },


### PR DESCRIPTION
## Summary
  - Bump the `parallel-web` SDK floor from `>=0.6.0` to `>=1.0.0,<2`
  - Add a `findall entity-search` command for fast, synchronous entity search — a low-latency alternative to the full create, poll, and result async FindAll flow
 
## Entity-search
    - Supports `companies` and `people` entity types (`-t/--entity-type`, required)
    - `-n/--match-limit` (5–1000, default 10)
    - Returns a ranked list of entities (name, url, description) and a `entity_set_id`
    - Example: `parallel-cli findall entity-search "AI startups in healthcare" -t companies -n 25`