### PR TITLE
feat: add turbo mode for search

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -880,12 +880,14 @@ main.add_command(create_skills_group(console, _handle_error, EXIT_BAD_INPUT, EXI
 # Search Command
 # =============================================================================
 
-# Beta -> V1 mode mapping. Beta had three modes; V1 has two. We keep the old
-# values as accepted CLI inputs and translate them so existing scripts work.
+# Beta -> V1 mode mapping. Beta had three modes; V1 has three (turbo/basic/
+# advanced). We keep the old values as accepted CLI inputs and translate them so
+# existing scripts work.
 _SEARCH_MODE_MAP = {
     "fast": "basic",
     "one-shot": "basic",
     "agentic": "advanced",
+    "turbo": "turbo",
     "basic": "basic",
     "advanced": "advanced",
 }
@@ -956,7 +958,7 @@ def build_search_v1_kwargs(
     "--mode",
     type=click.Choice(list(_SEARCH_MODE_MAP.keys())),
     default="basic",
-    help="Search mode (one-shot/fast → basic, agentic → advanced)",
+    help="Search mode: turbo (fastest), basic, or advanced (one-shot/fast → basic, agentic → advanced)",
     show_default=True,
 )
 @click.option("--max-results", type=int, help="Maximum results (defaults to server-side default of 10)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "parallel-web>=1.0.0,<2",
+    "parallel-web>=1.1.0,<2",
     "python-dotenv>=1.0.0",
     # CLI dependencies (minimal - search, extract, enrich with CLI args)
     "click>=8.1.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1244,8 +1244,8 @@ class TestBuildSearchV1Kwargs:
         assert kwargs["mode"] == "advanced"
 
     def test_new_mode_values_pass_through(self):
-        """Should accept V1-native `basic`/`advanced` values directly."""
-        for new_mode in ("basic", "advanced"):
+        """Should accept V1-native `turbo`/`basic`/`advanced` values directly."""
+        for new_mode in ("turbo", "basic", "advanced"):
             kwargs = build_search_v1_kwargs(
                 objective=None,
                 query=("q",),

--- a/uv.lock
+++ b/uv.lock
@@ -1657,7 +1657,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1667,9 +1667,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/ca/78e12e5aa440fc45f66536b8c53941240912516ebd66b814abf229a12a25/parallel_web-1.0.0.tar.gz", hash = "sha256:d672771ed7fd642c5cad5b0d0d48b4fc93275446e5289757a6b1392bc0975448", size = 159658, upload-time = "2026-06-02T18:43:43.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/1d/fefb7d976d3ea2ae61b0d9d6d638c9f837cb9fb96532680b148f33f322a1/parallel_web-1.1.0.tar.gz", hash = "sha256:97d6dbe4aa49b8c2c93f71f818d8883bc45bee71928bd945b7f616cecaacec0d", size = 157720, upload-time = "2026-06-08T18:22:21.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/94/fe4a09f1d8b28526363ccff41fc3a2b3cd716356e6fb296547d717df8671/parallel_web-1.0.0-py3-none-any.whl", hash = "sha256:627e6fea94d72a944b1b382735c169f0aa64abdb7749de1efbdd21a283d467db", size = 170701, upload-time = "2026-06-02T18:43:42.071Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ec/276c02247c973b02e254c9daac1844ccd38f385850c50e00ad46548eb5db/parallel_web-1.1.0-py3-none-any.whl", hash = "sha256:598aa5613c1146a3880a41592c343b0b9c0f51cff7c1ea6d10bc586d2df5e2f9", size = 167673, upload-time = "2026-06-08T18:22:20.068Z" },
 ]
 
 [[package]]
@@ -1765,7 +1765,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "nest-asyncio", marker = "extra == 'duckdb'", specifier = ">=1.6.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.3.0" },
-    { name = "parallel-web", specifier = ">=1.0.0,<2" },
+    { name = "parallel-web", specifier = ">=1.1.0,<2" },
     { name = "parallel-web-tools", extras = ["all", "spark"], marker = "extra == 'dev'" },
     { name = "parallel-web-tools", extras = ["cli"], marker = "extra == 'bigquery'" },
     { name = "parallel-web-tools", extras = ["cli", "polars"], marker = "extra == 'duckdb'" },


### PR DESCRIPTION
## Summary
This bumps sdk version and add search turbo mode. 
```
parallel-cli search --help

  --mode [fast|one-shot|agentic|turbo|basic|advanced]
                                  Search mode: turbo (fastest), basic, or
                                  advanced (one-shot/fast → basic, agentic →
                                  advanced)  [default: basic]
```