### PR TITLE
Note recall optimization in findall entity-search help text

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -2787,7 +2787,8 @@ def findall_entity_search(
 ):
     """Return ranked entities matching a natural language objective.
 
-    A best-effort, low-latency search. For comprehensive match evaluation and
+    A best-effort, low-latency search optimized for recall: results are ranked
+    but not individually verified. For comprehensive match evaluation and
     enrichment, use `parallel-cli findall run` instead.
 
     OBJECTIVE is a natural language description of what to find.


### PR DESCRIPTION
One-line addition to the `findall entity-search` command docstring so `--help` states the same contract as the [Entity Search docs](https://docs.parallel.ai/findall-api/entity-search): the search is optimized for recall — results are ranked but not individually verified — and `findall run` remains the path for comprehensive match evaluation and enrichment.

No behavior changes; README and core docstrings already describe the command as best-effort/low-latency and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)