### PR TITLE
fix: stabilize npm publishing runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,13 +128,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm
-        # Trusted publishing (OIDC) requires npm >= 11.5.1, newer than the
-        # version bundled with Node 20.
-        run: npm install -g npm@latest
+        # Trusted publishing (OIDC) requires npm >= 11.5.1. Pin the major so
+        # a future npm release cannot unexpectedly require a newer runtime.
+        run: npm install -g npm@11
 
       - name: Get version from tag
         id: version


### PR DESCRIPTION
## Summary

- run the npm publishing job on Node.js 24
- pin npm to major version 11 instead of installing `npm@latest`

## Root cause

The `v0.8.1rc1` release workflow installed npm 12 through `npm@latest`, but npm 12 does not support the workflow's Node.js 20 runtime. The failure occurred before the npm version and publish steps.

This change also prevents a future npm major release from unexpectedly breaking the publishing job again.