### PR TITLE
feat: support V1 native fast search mode

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -1088,18 +1088,19 @@ def memory_clear(memory_scope_key: str | None, confirm_clear: bool, output_json:
 # Search Command
 # =============================================================================
 
-# Beta -> V1 mode mapping. Beta had three modes; V1 has three (turbo/basic/
-# advanced). We keep the old values as accepted CLI inputs and translate them so
-# existing scripts work.
+# Search mode translation. V1 accepts turbo/fast/basic/advanced natively; the
+# Beta-only values stay accepted CLI inputs and are translated so existing
+# scripts keep working. Beta's `fast` used to downgrade to basic, but V1 now has
+# a native fast mode of its own, so the name passes through.
 _SEARCH_MODE_MAP = {
-    "fast": "basic",
-    "one-shot": "basic",
-    "agentic": "advanced",
     "turbo": "turbo",
+    "fast": "fast",
     "basic": "basic",
     "advanced": "advanced",
+    "one-shot": "basic",
+    "agentic": "advanced",
 }
-_DEPRECATED_SEARCH_MODES = {"fast", "one-shot", "agentic"}
+_DEPRECATED_SEARCH_MODES = {"one-shot", "agentic"}
 
 
 def _emit_deprecation(message: str) -> None:
@@ -1166,7 +1167,8 @@ def build_search_v1_kwargs(
     "--mode",
     type=click.Choice(list(_SEARCH_MODE_MAP.keys())),
     default="basic",
-    help="Search mode: turbo (fastest), basic, or advanced (one-shot/fast → basic, agentic → advanced)",
+    help="Search mode: turbo (fastest), fast (high quality within ~1s), basic, "
+    "or advanced (highest quality; one-shot → basic, agentic → advanced)",
     show_default=True,
 )
 @click.option("--max-results", type=int, help="Maximum results (defaults to server-side default of 10)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "parallel-web>=1.2.0,<2",
+    "parallel-web>=1.3.0,<2",
     "python-dotenv>=1.0.0",
     # CLI dependencies (minimal - search, extract, enrich with CLI args)
     "click>=8.1.0",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1201,20 +1201,6 @@ class TestBuildSearchV1Kwargs:
         assert kwargs["search_queries"] == ["first query", "second query"]
         assert kwargs["objective"] == "overarching goal"
 
-    def test_mode_fast_maps_to_basic(self):
-        """Should map old `fast` mode to V1 `basic`."""
-        kwargs = build_search_v1_kwargs(
-            objective=None,
-            query=("q",),
-            mode="fast",
-            max_results=None,
-            source_policy=None,
-            excerpt_max_chars_per_result=None,
-            excerpt_max_chars_total=None,
-            fetch_policy=None,
-        )
-        assert kwargs["mode"] == "basic"
-
     def test_mode_one_shot_maps_to_basic(self):
         """Should map old `one-shot` mode to V1 `basic`."""
         kwargs = build_search_v1_kwargs(
@@ -1244,8 +1230,8 @@ class TestBuildSearchV1Kwargs:
         assert kwargs["mode"] == "advanced"
 
     def test_new_mode_values_pass_through(self):
-        """Should accept V1-native `turbo`/`basic`/`advanced` values directly."""
-        for new_mode in ("turbo", "basic", "advanced"):
+        """Should accept V1-native `turbo`/`fast`/`basic`/`advanced` values directly."""
+        for new_mode in ("turbo", "fast", "basic", "advanced"):
             kwargs = build_search_v1_kwargs(
                 objective=None,
                 query=("q",),
@@ -1621,7 +1607,6 @@ class TestSearchDeprecationWarnings:
     @pytest.mark.parametrize(
         "deprecated_mode,expected_new",
         [
-            ("fast", "basic"),
             ("one-shot", "basic"),
             ("agentic", "advanced"),
         ],
@@ -1644,7 +1629,7 @@ class TestSearchDeprecationWarnings:
         call_kwargs = mock_cli_client.search.call_args.kwargs
         assert call_kwargs["mode"] == expected_new
 
-    @pytest.mark.parametrize("new_mode", ["basic", "advanced"])
+    @pytest.mark.parametrize("new_mode", ["turbo", "fast", "basic", "advanced"])
     def test_new_modes_do_not_emit_warning(self, runner, mock_cli_client, new_mode):
         """Should not warn when V1-native mode values are used."""
         self._setup_mock_search(mock_cli_client)

--- a/uv.lock
+++ b/uv.lock
@@ -1657,7 +1657,7 @@ wheels = [
 
 [[package]]
 name = "parallel-web"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1667,9 +1667,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/fc/4bc3d44a1927a2b253662f1359053cf43529c940df93bc22139f494f7deb/parallel_web-1.2.0.tar.gz", hash = "sha256:8fa8120cc92b0567cd095cbcb85520856984b4b4ea6ac20ad2fa85eec4b713ab", size = 161683, upload-time = "2026-08-10T18:16:09.795Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/76/ac6596ce1ec2f105e2288d53e022f3cda65600e8c03970b3a6c248bce604/parallel_web-1.3.0.tar.gz", hash = "sha256:a0aaa45535ac907b0eb94f636f6a0c142f8b1658add0510f7dd9a26e8a81b4ce", size = 161808, upload-time = "2026-08-12T21:45:02.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/9c/bb8d0c10a9219af875fdfa0a68f5e2fb6aa4f716dc9d7b9338d77a7f78a7/parallel_web-1.2.0-py3-none-any.whl", hash = "sha256:a050382c98ec6b7dac71988a67cd206e99740fb0a68bca2af6f7c403ed54f5aa", size = 175758, upload-time = "2026-08-10T18:16:08.634Z" },
+    { url = "https://files.pythonhosted.org/packages/67/35/e753a70f15300f93dae065b5348016fce13f29f5cf5263919d8b33128af1/parallel_web-1.3.0-py3-none-any.whl", hash = "sha256:dc7e93ee500e6773141e8de2e04ad468a39a21cefafa2aff1d833c6e5566690d", size = 175849, upload-time = "2026-08-12T21:45:00.821Z" },
 ]
 
 [[package]]
@@ -1765,7 +1765,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "nest-asyncio", marker = "extra == 'duckdb'", specifier = ">=1.6.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.3.0" },
-    { name = "parallel-web", specifier = ">=1.2.0,<2" },
+    { name = "parallel-web", specifier = ">=1.3.0,<2" },
     { name = "parallel-web-tools", extras = ["all", "spark"], marker = "extra == 'dev'" },
     { name = "parallel-web-tools", extras = ["cli"], marker = "extra == 'bigquery'" },
     { name = "parallel-web-tools", extras = ["cli", "polars"], marker = "extra == 'duckdb'" },


### PR DESCRIPTION
The V1 Search API added a native `fast` mode — high quality search within a one-second latency budget, sitting between turbo and basic — available in parallel-web 1.3.0.

`--mode fast` now passes through as a first-class V1 value with no warning. The remaining Beta-only names (`one-shot`, `agentic`) keep their translation and deprecation notice. Mode choices are reordered to list V1-native values before the legacy aliases, and the parallel-web floor moves to 1.3.0, whose search() typing includes "fast".
