### PR TITLE
Make managed CLI skill updates discoverable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ parallel-cli
     └── clear               # Permanently clear selected Memory
 ```
 
+Run `parallel-cli skills install` to install or update agent skills. When using
+`--skill`, other managed skills are removed; unmanaged skills are preserved.
+
 ## Quick Start
 
 ### 1. Authenticate
@@ -235,28 +238,6 @@ parallel-cli memory clear --scope-key workspace_acme --confirm-clear --json
 Omit `--scope-key` / `--memory-scope-key` to use personal Memory when the
 credential and account are eligible. Application credentials require a stable
 scope key containing only letters, digits, underscores, or hyphens.
-
-### 7. Install or Update Agent Skills
-
-```bash
-# List the available Parallel agent skills
-parallel-cli skills list
-
-# Install all skills, or update managed skills after updating parallel-cli
-parallel-cli skills install
-
-# Replace the managed set with only the selected skills
-parallel-cli skills install --skill parallel-web-search
-
-# Perform a clean reinstall of managed skills when needed
-parallel-cli skills reinstall
-```
-
-Skills install globally to `~/.agents/skills` and, when Claude Code is present,
-`~/.claude/skills`. Add `--project` to install into the current project's skill
-directories instead. Repeating `install` refreshes CLI-managed skills; `--skill`
-removes previously managed skills that are not selected. Unmanaged skills are
-never overwritten or removed.
 
 ## Non-Interactive Mode (for AI Agents & Scripts)
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ parallel-cli
 │   ├── cancel              # Cancel a monitor (irreversible)
 │   ├── events              # List events for a monitor
 │   └── trigger             # Trigger an immediate one-off run
+├── skills                  # Install, update, and manage Parallel agent skills
+│   ├── install             # Install or update managed Parallel skills
+│   ├── list                # List available Parallel skills
+│   ├── reinstall           # Cleanly reinstall managed Parallel skills
+│   └── uninstall           # Remove only CLI-managed Parallel skills
 └── memory                  # Saved Task, Monitor, and FindAll entries
     ├── retrieve            # Search Memory or list recent entries
     ├── evict               # Remove one entry from Memory
@@ -230,6 +235,28 @@ parallel-cli memory clear --scope-key workspace_acme --confirm-clear --json
 Omit `--scope-key` / `--memory-scope-key` to use personal Memory when the
 credential and account are eligible. Application credentials require a stable
 scope key containing only letters, digits, underscores, or hyphens.
+
+### 7. Install or Update Agent Skills
+
+```bash
+# List the available Parallel agent skills
+parallel-cli skills list
+
+# Install all skills, or update managed skills after updating parallel-cli
+parallel-cli skills install
+
+# Replace the managed set with only the selected skills
+parallel-cli skills install --skill parallel-web-search
+
+# Perform a clean reinstall of managed skills when needed
+parallel-cli skills reinstall
+```
+
+Skills install globally to `~/.agents/skills` and, when Claude Code is present,
+`~/.claude/skills`. Add `--project` to install into the current project's skill
+directories instead. Repeating `install` refreshes CLI-managed skills; `--skill`
+removes previously managed skills that are not selected. Unmanaged skills are
+never overwritten or removed.
 
 ## Non-Interactive Mode (for AI Agents & Scripts)
 

--- a/parallel_web_tools/cli/skills.py
+++ b/parallel_web_tools/cli/skills.py
@@ -35,9 +35,7 @@ def create_skills_group(
     def skills() -> None:
         """Install, update, and manage Parallel agent skills.
 
-        Run parallel-cli skills install to install or update managed skills after
-        updating parallel-cli. Use parallel-cli skills reinstall for a clean reinstall.
-        Skills not managed by parallel-cli are left untouched.
+        Run parallel-cli skills install to install or update managed skills.
 
         Downloads come from skills.parallel.ai. Set PARALLEL_SKILLS_INDEX_URL to use a custom index.
 
@@ -102,8 +100,6 @@ def create_skills_group(
     @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
     def skills_install(project: bool, skill_names: tuple[str, ...], output_json: bool) -> None:
         """Install or update Parallel skills from skills.parallel.ai.
-
-        Run again after updating parallel-cli to refresh managed skills.
 
         When --skill is provided, the managed install set is replaced with exactly
         the listed skills. Unmanaged skills are never overwritten or removed.
@@ -191,7 +187,7 @@ def create_skills_group(
         """Reinstall Parallel skills (uninstall managed set then install fresh).
 
         When --skill is provided, the managed install set is replaced with exactly
-        the listed skills. Unmanaged skills are never overwritten or removed.
+        the listed skills.
         """
         from parallel_web_tools.core.skills import (
             SkillsError,

--- a/parallel_web_tools/cli/skills.py
+++ b/parallel_web_tools/cli/skills.py
@@ -33,7 +33,11 @@ def create_skills_group(
 
     @click.group(name="skills")
     def skills() -> None:
-        """Install and manage Parallel agent skills.
+        """Install, update, and manage Parallel agent skills.
+
+        Run parallel-cli skills install to install or update managed skills after
+        updating parallel-cli. Use parallel-cli skills reinstall for a clean reinstall.
+        Skills not managed by parallel-cli are left untouched.
 
         Downloads come from skills.parallel.ai. Set PARALLEL_SKILLS_INDEX_URL to use a custom index.
 
@@ -93,14 +97,16 @@ def create_skills_group(
         "--skill",
         "skill_names",
         multiple=True,
-        help="Skill name to install (repeatable). Defaults to all. Skills not listed will be removed.",
+        help="Skill name to install (repeatable). Defaults to all. Other managed skills will be removed.",
     )
     @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
     def skills_install(project: bool, skill_names: tuple[str, ...], output_json: bool) -> None:
-        """Install Parallel skills from skills.parallel.ai.
+        """Install or update Parallel skills from skills.parallel.ai.
+
+        Run again after updating parallel-cli to refresh managed skills.
 
         When --skill is provided, the managed install set is replaced with exactly
-        the listed skills.
+        the listed skills. Unmanaged skills are never overwritten or removed.
         """
         from parallel_web_tools.core.skills import (
             SkillsError,
@@ -178,14 +184,14 @@ def create_skills_group(
         "--skill",
         "skill_names",
         multiple=True,
-        help="Skill name to reinstall (repeatable). Defaults to all. Skills not listed will be removed.",
+        help="Skill name to reinstall (repeatable). Defaults to all. Other managed skills will be removed.",
     )
     @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
     def skills_reinstall(project: bool, skill_names: tuple[str, ...], output_json: bool) -> None:
         """Reinstall Parallel skills (uninstall managed set then install fresh).
 
         When --skill is provided, the managed install set is replaced with exactly
-        the listed skills.
+        the listed skills. Unmanaged skills are never overwritten or removed.
         """
         from parallel_web_tools.core.skills import (
             SkillsError,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2432,40 +2432,27 @@ class TestEnrichRunJsonOutput:
 
 
 class TestSkillsCommands:
-    def test_main_help_mentions_skill_updates(self, runner):
-        result = runner.invoke(main, ["--help"])
-
-        assert result.exit_code == 0
-        assert "Install, update, and manage Parallel agent skills" in result.output
-
-    def test_skills_help_mentions_update_commands_and_cdn(self, runner):
+    def test_skills_help_mentions_updates_cdn_and_managed_replacement(self, runner):
         result = runner.invoke(main, ["skills", "--help"])
 
         assert result.exit_code == 0
         help_text = " ".join(result.output.split())
         assert "parallel-cli skills install to install or update managed skills" in help_text
-        assert "parallel-cli skills reinstall for a clean reinstall" in help_text
-        assert "Skills not managed by parallel-cli are left untouched" in help_text
         assert "skills.parallel.ai" in result.output
         assert "PARALLEL_SKILLS_INDEX_URL" in result.output
 
-    def test_skills_install_help_explains_updates_and_managed_replacement(self, runner):
         result = runner.invoke(main, ["skills", "install", "--help"])
 
         assert result.exit_code == 0
         help_text = " ".join(result.output.split())
         assert "Install or update Parallel skills" in help_text
-        assert "Run again after updating parallel-cli to refresh managed skills" in help_text
         assert "Unmanaged skills are never overwritten or removed" in help_text
         assert "Other managed skills will be removed" in help_text
 
-    def test_skills_reinstall_help_preserves_unmanaged_skills(self, runner):
         result = runner.invoke(main, ["skills", "reinstall", "--help"])
 
         assert result.exit_code == 0
-        help_text = " ".join(result.output.split())
-        assert "Unmanaged skills are never overwritten or removed" in help_text
-        assert "Other managed skills will be removed" in help_text
+        assert "Other managed skills will be removed" in " ".join(result.output.split())
 
     def test_skills_list_json(self, runner):
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2432,18 +2432,40 @@ class TestEnrichRunJsonOutput:
 
 
 class TestSkillsCommands:
-    def test_skills_help_mentions_cdn_and_replacement_behavior(self, runner):
+    def test_main_help_mentions_skill_updates(self, runner):
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Install, update, and manage Parallel agent skills" in result.output
+
+    def test_skills_help_mentions_update_commands_and_cdn(self, runner):
         result = runner.invoke(main, ["skills", "--help"])
 
         assert result.exit_code == 0
+        help_text = " ".join(result.output.split())
+        assert "parallel-cli skills install to install or update managed skills" in help_text
+        assert "parallel-cli skills reinstall for a clean reinstall" in help_text
+        assert "Skills not managed by parallel-cli are left untouched" in help_text
         assert "skills.parallel.ai" in result.output
         assert "PARALLEL_SKILLS_INDEX_URL" in result.output
 
+    def test_skills_install_help_explains_updates_and_managed_replacement(self, runner):
         result = runner.invoke(main, ["skills", "install", "--help"])
 
         assert result.exit_code == 0
-        assert "Skills not" in result.output
-        assert "listed will be removed" in result.output
+        help_text = " ".join(result.output.split())
+        assert "Install or update Parallel skills" in help_text
+        assert "Run again after updating parallel-cli to refresh managed skills" in help_text
+        assert "Unmanaged skills are never overwritten or removed" in help_text
+        assert "Other managed skills will be removed" in help_text
+
+    def test_skills_reinstall_help_preserves_unmanaged_skills(self, runner):
+        result = runner.invoke(main, ["skills", "reinstall", "--help"])
+
+        assert result.exit_code == 0
+        help_text = " ".join(result.output.split())
+        assert "Unmanaged skills are never overwritten or removed" in help_text
+        assert "Other managed skills will be removed" in help_text
 
     def test_skills_list_json(self, runner):
         with (

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -376,23 +376,6 @@ class TestCollisionGuard:
         assert result["skipped_skills"] == []
         assert not (install_dir / "parallel-web-search" / "stale.md").exists()
 
-    def test_reinstall_leaves_unmanaged_same_named_skill_untouched(self, monkeypatch, tmp_path):
-        self._patch(monkeypatch)
-        install_dir = tmp_path / ".claude" / "skills"
-        unmanaged_skill = install_dir / "parallel-web-search"
-        unmanaged_skill.mkdir(parents=True)
-        (unmanaged_skill / "SKILL.md").write_text("hand written")
-        skills.install_skills([install_dir], selected_skills=["parallel-web-extract"])
-
-        result = skills.reinstall_skills([install_dir], selected_skills=["parallel-web-extract", "parallel-web-search"])
-
-        assert (unmanaged_skill / "SKILL.md").read_text() == "hand written"
-        assert result["removed_skills"] == ["parallel-web-extract"]
-        assert result["installed_skills"] == ["parallel-web-extract"]
-        assert result["skipped_skills"] == [{"skill": "parallel-web-search", "install_dir": str(install_dir)}]
-        manifest = json.loads((install_dir / skills.MANIFEST_FILE_NAME).read_text())
-        assert manifest["installed_skills"] == ["parallel-web-extract"]
-
     def test_skip_is_per_directory(self, monkeypatch, tmp_path):
         self._patch(monkeypatch)
         agents_dir = tmp_path / ".agents" / "skills"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -376,6 +376,23 @@ class TestCollisionGuard:
         assert result["skipped_skills"] == []
         assert not (install_dir / "parallel-web-search" / "stale.md").exists()
 
+    def test_reinstall_leaves_unmanaged_same_named_skill_untouched(self, monkeypatch, tmp_path):
+        self._patch(monkeypatch)
+        install_dir = tmp_path / ".claude" / "skills"
+        unmanaged_skill = install_dir / "parallel-web-search"
+        unmanaged_skill.mkdir(parents=True)
+        (unmanaged_skill / "SKILL.md").write_text("hand written")
+        skills.install_skills([install_dir], selected_skills=["parallel-web-extract"])
+
+        result = skills.reinstall_skills([install_dir], selected_skills=["parallel-web-extract", "parallel-web-search"])
+
+        assert (unmanaged_skill / "SKILL.md").read_text() == "hand written"
+        assert result["removed_skills"] == ["parallel-web-extract"]
+        assert result["installed_skills"] == ["parallel-web-extract"]
+        assert result["skipped_skills"] == [{"skill": "parallel-web-search", "install_dir": str(install_dir)}]
+        manifest = json.loads((install_dir / skills.MANIFEST_FILE_NAME).read_text())
+        assert manifest["installed_skills"] == ["parallel-web-extract"]
+
     def test_skip_is_per_directory(self, monkeypatch, tmp_path):
         self._patch(monkeypatch)
         agents_dir = tmp_path / ".agents" / "skills"


### PR DESCRIPTION
## What changed
- Add the skills command family and install/update examples to the README.
- Clarify that rerunning `parallel-cli skills install` refreshes managed skills and that `--skill` only replaces the managed set.
- Cover CLI help and preservation of unmanaged skills during reinstalls.

## Why
The CLI already supports skill updates, but users have no clear guidance for finding or safely using that workflow.

## Validation
- Full suite: 846 tests passed.
- Focused CLI and skill tests: 264 passed.
- Ruff, Tach, ty, lockfile verification, wheel build, and packaged CLI help all passed.