### PR TITLE
fix: preserve non-ASCII characters in JSON output

### DIFF
--- a/parallel_web_tools/cli/commands.py
+++ b/parallel_web_tools/cli/commands.py
@@ -301,12 +301,12 @@ def write_json_output(data: dict[str, Any], output_file: str | None, output_json
         output_json: If True, print JSON to stdout.
     """
     if output_file:
-        with open(output_file, "w") as f:
-            json.dump(data, f, indent=2)
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
         console.print(f"[dim]Results saved to {output_file}[/dim]\n")
 
     if output_json:
-        print(json.dumps(data, indent=2))
+        print(json.dumps(data, indent=2, ensure_ascii=False))
 
 
 def parse_columns(columns_json: str | None) -> list[dict[str, str]] | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -939,6 +939,15 @@ class TestWriteJsonOutput:
         output = json.loads(capsys.readouterr().out)
         assert output == data
 
+    def test_preserves_non_ascii_characters(self, tmp_path, capsys):
+        output_file = tmp_path / "output.json"
+        data = {"title": "中文搜索"}
+
+        write_json_output(data, str(output_file), output_json=True)
+
+        assert "中文搜索" in output_file.read_text(encoding="utf-8")
+        assert "中文搜索" in capsys.readouterr().out
+
     def test_write_to_both(self, tmp_path, capsys):
         """Should write to file AND stdout when both specified."""
         output_file = tmp_path / "output.json"


### PR DESCRIPTION
## Summary
- emit non-ASCII characters directly in CLI JSON output instead of escaping them as `\uXXXX`
- write JSON output files explicitly as UTF-8
- add regression coverage for both file and stdout output

## Test plan
- [x] `uv run ruff check --fix .`
- [x] `uv run ruff format .`
- [x] `uv run tach check`
- [x] `uv run ty check`
- [x] `uv run pytest -q` (843 passed)